### PR TITLE
feature: background compression & stability (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 1.3.0
+
+### New
+
+- **Background execution** — pass an optional `BackgroundConfig` to `compressVideo` / `compressVideos` to keep a compression running while the app is backgrounded or the screen is off. Omitting it (the default) preserves the previous behaviour and is fully backwards compatible. Behaviour is platform-specific:
+  - **Android** — runs under a foreground service. Its ongoing notification shows live progress (bar + %), an elapsed-time timer, the current file name (single) or a done/total count like `2 / 5` (batch, since videos compress in parallel) and a **Cancel** action. The title comes from `BackgroundConfig`. The plugin declares the service + receiver and requests `POST_NOTIFICATIONS` (Android 13+) automatically; no host-app manifest changes are required.
+  - **macOS** — suppresses App Nap (`NSProcessInfo.beginActivity`) so the process keeps full CPU while in the background. The notification fields are ignored.
+  - **iOS** — not supported. iOS suspends backgrounded apps within seconds and offers no sanctioned way to keep video transcoding running, so passing a `BackgroundConfig` has no effect there; the compression pauses and resumes when the app returns to the foreground.
+- Example app gains a **“Run in background”** toggle in both the single and batch flows.
+
 # 1.2.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Extreme high bitrates are reduced while maintaining good video quality, resultin
 - **Thumbnail extraction** — grab a JPEG frame at any timecode via `getVideoThumbnail`.
 - **Progress streams** — real-time percentage for single (`onProgressUpdated`) and per-item + overall for batch (`onBatchUpdate`).
 - **Cancellation** — cancel any in-progress compression with a single call.
+- **Background execution** — keep compressing while the app is backgrounded or the screen is off via `BackgroundConfig` (Android foreground service; macOS App Nap suppression; not supported on iOS).
 - **Typed exceptions** — `PermissionDeniedException`, `UnsupportedVideoException`, `VideoNotFoundException`, and more — react programmatically instead of parsing strings.
 - **Minimum bitrate guard** — optionally skip compression for already-low-bitrate videos.
 - **Disable audio** — generate silent videos when audio isn't needed.
@@ -61,7 +62,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  light_compressor_v2: ^1.2.0
+  light_compressor_v2: ^1.3.0
 ```
 
 Then run:
@@ -137,6 +138,40 @@ for (final (int i, Result r) in results.indexed) {
   if (r is OnSuccess) print('Video $i → ${r.destinationPath}');
 }
 ```
+
+### Run in the background
+
+Pass a `BackgroundConfig` to keep a compression running while the app is
+backgrounded or the screen turns off. Works for both `compressVideo` and
+`compressVideos`:
+
+```dart
+final result = await compressor.compressVideo(
+  path: '/path/to/source.mp4',
+  videoQuality: VideoQuality.medium,
+  video: Video(videoName: 'compressed.mp4'),
+  android: AndroidConfig(saveAt: SaveAt.Movies),
+  ios: IOSConfig(saveInGallery: true),
+  background: const BackgroundConfig(
+    notificationTitle: 'Compressing video',
+  ),
+);
+```
+
+Platform behaviour differs significantly:
+
+- **Android** — runs under a foreground service. The ongoing notification shows
+  live progress (bar + %), elapsed time, the current file (single) or
+  a `done / total` count (batch) and a Cancel action. The title comes from
+  `BackgroundConfig`. The plugin declares the service + receiver and requests
+  `POST_NOTIFICATIONS` (Android 13+) automatically — no host-app manifest
+  changes are needed.
+- **macOS** — suppresses App Nap so the process keeps full CPU in the
+  background. The notification fields are ignored.
+- **iOS** — **not supported.** iOS suspends backgrounded apps within seconds
+  and offers no sanctioned way to keep video transcoding running, so passing a
+  `BackgroundConfig` has no effect; the compression pauses and resumes when the
+  app returns to the foreground.
 
 ### Listen to progress
 
@@ -231,6 +266,7 @@ try {
 | `video` | `Video` | ✅ | — | Output video configuration (name, resolution, bitrate). |
 | `isMinBitrateCheckEnabled` | `bool` | | `true` | Skip compression when source bitrate is below 2 Mbps. |
 | `disableAudio` | `bool?` | | `false` | Strip the audio track from the output. |
+| `background` | `BackgroundConfig?` | | `null` | Keep running while the app is backgrounded. See [`BackgroundConfig`](#backgroundconfig). |
 
 ### `compressVideos()` → `Future<List<Result>>`
 
@@ -246,6 +282,7 @@ try {
 | `videoBitrateInMbps` | `int?` | | `null` | Custom bitrate in Mbps (overrides the preset). |
 | `disableAudio` | `bool` | | `false` | Strip the audio track from every output. |
 | `isMinBitrateCheckEnabled` | `bool` | | `true` | Skip compression when source bitrate is below 2 Mbps. |
+| `background` | `BackgroundConfig?` | | `null` | Keep the whole batch running while backgrounded. See [`BackgroundConfig`](#backgroundconfig). |
 
 ### `Video`
 
@@ -269,6 +306,14 @@ try {
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `saveInGallery` | `bool` | `true` | Save the compressed video to the photo library. |
+
+### `BackgroundConfig`
+
+Opt into background execution. `notificationTitle` is the Android foreground-service notification title; iOS and macOS ignore it.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `notificationTitle` | `String` | `'Compressing video'` | Title of the Android foreground-service notification. |
 
 ### `Result` types
 
@@ -358,6 +403,8 @@ All extend `LightCompressorException` (catch the base type to handle any):
 <!-- API ≥ 33 -->
 <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 ```
+
+**Background execution** — when you pass a `BackgroundConfig`, no manifest changes are required on your side. The plugin already declares the foreground service and the `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC` and `POST_NOTIFICATIONS` permissions, which merge into your app automatically; the `POST_NOTIFICATIONS` runtime prompt (Android 13+) is requested for you.
 
 **ProGuard** — no special ProGuard or R8 rules are required.
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.gurfdev.light_compressor_v2">
-</manifest>
 
+    <!-- Used only when a compression opts into background execution via
+         BackgroundConfig. Declared here so host apps inherit them automatically
+         through manifest merging. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+        <service
+            android:name=".CompressionForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+        <receiver
+            android:name=".CompressionCancelReceiver"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/CompressionCancelReceiver.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/CompressionCancelReceiver.kt
@@ -1,0 +1,18 @@
+package com.gurfdev.light_compressor_v2
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoCompressor
+
+/**
+ * Receives the "Cancel" action from the foreground-service notification and
+ * cancels the active compression. The library then delivers `onCancelled` to
+ * the running listener, which resolves the pending call and stops the service
+ * through the normal terminal path.
+ */
+class CompressionCancelReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        VideoCompressor.cancel()
+    }
+}

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/CompressionForegroundService.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/CompressionForegroundService.kt
@@ -1,0 +1,199 @@
+package com.gurfdev.light_compressor_v2
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+
+/**
+ * Minimal foreground service that acts as a process-lifetime anchor while a
+ * video compression runs, surfacing live status in its ongoing notification:
+ * a progress bar + percentage, an elapsed-time chronometer, the current file /
+ * batch position (as body text) and a Cancel action.
+ *
+ * It does **not** perform the compression itself — that keeps running in the
+ * plugin's coroutine inside the same process. Promoting the process to the
+ * foreground raises its importance so Android does not kill it while the app is
+ * backgrounded or the screen is off.
+ *
+ * Started and stopped explicitly by [LightCompressorPlugin] around a single
+ * compression call; progress and status are pushed in via [updateProgress].
+ */
+class CompressionForegroundService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val title = intent?.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
+        val text = intent?.getStringExtra(EXTRA_TEXT) ?: DEFAULT_TEXT
+
+        activeTitle = title
+        activeText = text
+        createChannelIfNeeded(this)
+        // Indeterminate bar until the first progress update arrives.
+        val notification = buildNotification(this, title, text, null)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+
+        // The service is started/stopped explicitly by the plugin around one
+        // compression, so it must not be recreated if the process is killed.
+        return START_NOT_STICKY
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "light_compressor_compression"
+        private const val CHANNEL_NAME = "Video compression"
+        private const val NOTIFICATION_ID = 0xC0FFEE
+        private const val DEFAULT_TITLE = "Compressing video"
+        private const val DEFAULT_TEXT = "Video compression in progress…"
+
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_TEXT = "text"
+
+        // State for the currently running compression. Held here so progress
+        // updates can rebuild the notification in place. Only one runs at a time.
+        @Volatile private var activeTitle: String? = null
+        @Volatile private var activeText: String? = null
+        @Volatile private var lastPercent = -1
+        @Volatile private var startWhen = 0L
+
+        /** Starts the foreground service with the given notification content. */
+        fun start(context: Context, title: String, text: String) {
+            activeTitle = title
+            activeText = text
+            lastPercent = -1
+            startWhen = System.currentTimeMillis()
+            val intent = Intent(context, CompressionForegroundService::class.java).apply {
+                putExtra(EXTRA_TITLE, title)
+                putExtra(EXTRA_TEXT, text)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        /**
+         * Updates the ongoing notification with [percent] (0–100) and, when
+         * provided, a new body [text] (e.g. the current file / batch position).
+         * Posting to the same notification id updates it in place. De-duplicates
+         * when neither percent nor text changed, and is a no-op when the service
+         * is not running or notifications are not granted.
+         */
+        fun updateProgress(context: Context, percent: Int, text: String?) {
+            val title = activeTitle ?: return
+            val clamped = percent.coerceIn(0, 100)
+            val newText = text ?: activeText
+            if (clamped == lastPercent && newText == activeText) return
+            lastPercent = clamped
+            if (newText != null) activeText = newText
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.POST_NOTIFICATIONS,
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return
+            }
+            NotificationManagerCompat.from(context).notify(
+                NOTIFICATION_ID,
+                buildNotification(context, title, activeText ?: DEFAULT_TEXT, clamped),
+            )
+        }
+
+        /** Stops the foreground service if it is running. */
+        fun stop(context: Context) {
+            activeTitle = null
+            activeText = null
+            lastPercent = -1
+            startWhen = 0L
+            context.stopService(Intent(context, CompressionForegroundService::class.java))
+        }
+
+        /**
+         * Builds the ongoing notification. A null [percent] renders an
+         * indeterminate bar; a value renders a determinate `0..100` bar plus a
+         * percentage sub-text. Always includes an elapsed-time chronometer and
+         * a Cancel action.
+         */
+        private fun buildNotification(
+            context: Context,
+            title: String,
+            text: String,
+            percent: Int?,
+        ): Notification {
+            val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setShowWhen(true)
+                .setWhen(if (startWhen > 0L) startWhen else System.currentTimeMillis())
+                .setUsesChronometer(true)
+                .addAction(
+                    android.R.drawable.ic_menu_close_clear_cancel,
+                    // System string, auto-localized by the OS (Cancel / Отмена / …).
+                    context.getString(android.R.string.cancel),
+                    cancelIntent(context),
+                )
+            if (percent == null) {
+                builder.setProgress(0, 0, true)
+            } else {
+                val p = percent.coerceIn(0, 100)
+                builder.setProgress(100, p, false)
+                builder.setSubText("$p%")
+            }
+            return builder.build()
+        }
+
+        private fun pendingFlags(): Int =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+
+        /** The Cancel action broadcasts to [CompressionCancelReceiver]. */
+        private fun cancelIntent(context: Context): PendingIntent {
+            val intent = Intent(context, CompressionCancelReceiver::class.java)
+            return PendingIntent.getBroadcast(context, 1, intent, pendingFlags())
+        }
+
+        private fun createChannelIfNeeded(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val manager =
+                    context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+                    manager.createNotificationChannel(
+                        NotificationChannel(
+                            CHANNEL_ID,
+                            CHANNEL_NAME,
+                            NotificationManager.IMPORTANCE_LOW,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/LightCompressorPlugin.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/LightCompressorPlugin.kt
@@ -497,25 +497,28 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
             AppSpecificStorageConfiguration()
         }
 
+        val background = parseBackground(call)
+        if (background != null) maybeRequestNotificationPermission()
+
         if (isSharedStorage) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 requestPermissionAndCompress33(
                     path, result, quality, isMinBitrateCheckEnabled,
                     videoBitrateInMbps, disableAudio, resizer,
-                    storageConfiguration, videoName
+                    storageConfiguration, videoName, background
                 )
             } else {
                 requestPermissionAndCompressLegacy(
                     path, result, quality, isMinBitrateCheckEnabled,
                     videoBitrateInMbps, disableAudio, resizer,
-                    storageConfiguration, videoName
+                    storageConfiguration, videoName, background
                 )
             }
         } else {
             compressVideo(
                 path, result, quality, isMinBitrateCheckEnabled,
                 videoBitrateInMbps, disableAudio, resizer,
-                storageConfiguration, videoName
+                storageConfiguration, videoName, background
             )
         }
     }
@@ -532,6 +535,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         resizer: VideoResizer?,
         storageConfiguration: StorageConfiguration,
         videoName: String,
+        background: BackgroundParams?,
     ) {
         val sourcePath = path
         // A MethodChannel reply may be submitted only once. A cancelled run can
@@ -541,8 +545,14 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         val replied = java.util.concurrent.atomic.AtomicBoolean(false)
         fun replyOnce(payload: Map<String, Any?>) {
             if (replied.compareAndSet(false, true)) {
+                if (background != null) CompressionForegroundService.stop(applicationContext)
                 Handler(Looper.getMainLooper()).post { result.success(gson.toJson(payload)) }
             }
+        }
+        if (background != null) {
+            CompressionForegroundService.start(
+                applicationContext, background.title, videoName,
+            )
         }
         VideoCompressor.start(
             context = applicationContext,
@@ -563,6 +573,11 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                 override fun onProgress(index: Int, percent: Float) {
                     Handler(Looper.getMainLooper()).post {
                         eventSink?.success(percent)
+                        if (background != null) {
+                            CompressionForegroundService.updateProgress(
+                                applicationContext, percent.toInt(), videoName,
+                            )
+                        }
                     }
                 }
 
@@ -643,6 +658,9 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
             AppSpecificStorageConfiguration()
         }
 
+        val background = parseBackground(call)
+        if (background != null) maybeRequestNotificationPermission()
+
         val count = paths.size
         val results = arrayOfNulls<Map<String, Any?>>(count)
         val percents = FloatArray(count)
@@ -661,10 +679,17 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                     event["index"] = index
                     batchEventSink?.success(event)
                     if (completed == count) {
+                        if (background != null) CompressionForegroundService.stop(applicationContext)
                         result.success(results.map { it ?: mapOf("onFailure" to "Unknown error") })
                     }
                 }
             }
+        }
+
+        if (background != null) {
+            CompressionForegroundService.start(
+                applicationContext, background.title, "0 / $count",
+            )
         }
 
         VideoCompressor.start(
@@ -693,6 +718,14 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                             "percent" to percent.toDouble(),
                             "overallPercent" to overall.toDouble()
                         ))
+                        if (background != null) {
+                            // Videos compress in parallel, so there is no single
+                            // "current" index — show a language-neutral
+                            // done/total count instead.
+                            CompressionForegroundService.updateProgress(
+                                applicationContext, overall.toInt(), "$completed / $count",
+                            )
+                        }
                     }
                 }
 
@@ -731,7 +764,8 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         path: String, result: Result, quality: VideoQuality,
         isMinBitrateCheckEnabled: Boolean, videoBitrateInMbps: Int?,
         disableAudio: Boolean, resizer: VideoResizer?,
-        storageConfiguration: StorageConfiguration, videoName: String
+        storageConfiguration: StorageConfiguration, videoName: String,
+        background: BackgroundParams?
     ) {
         if (ContextCompat.checkSelfPermission(
                 activity, Manifest.permission.READ_MEDIA_VIDEO
@@ -750,7 +784,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         }
         compressVideo(
             path, result, quality, isMinBitrateCheckEnabled,
-            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName
+            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background
         )
     }
 
@@ -758,7 +792,8 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         path: String, result: Result, quality: VideoQuality,
         isMinBitrateCheckEnabled: Boolean, videoBitrateInMbps: Int?,
         disableAudio: Boolean, resizer: VideoResizer?,
-        storageConfiguration: StorageConfiguration, videoName: String
+        storageConfiguration: StorageConfiguration, videoName: String,
+        background: BackgroundParams?
     ) {
         val permissions = arrayOf(
             Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -769,7 +804,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         }
         compressVideo(
             path, result, quality, isMinBitrateCheckEnabled,
-            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName
+            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background
         )
     }
 
@@ -777,6 +812,44 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         permissions.all {
             ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
         }
+
+    // MARK: - Background execution
+
+    /** Notification content for the Android foreground service. */
+    private data class BackgroundParams(
+        val title: String,
+    )
+
+    /**
+     * Parses the optional `background` map sent from Dart. Returns `null` when
+     * background execution was not requested, in which case the compression
+     * runs in-process exactly as before.
+     */
+    private fun parseBackground(call: MethodCall): BackgroundParams? {
+        val map = call.argument<Map<String, Any?>>("background") ?: return null
+        return BackgroundParams(
+            title = (map["notificationTitle"] as? String) ?: "Compressing video",
+        )
+    }
+
+    /**
+     * Requests the POST_NOTIFICATIONS runtime permission (Android 13+) so the
+     * foreground-service notification can be shown. Best-effort and
+     * non-blocking: compression proceeds regardless of the outcome — only the
+     * notification is hidden if the user denies it.
+     */
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ::activity.isInitialized &&
+            ContextCompat.checkSelfPermission(
+                activity, Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), 3,
+            )
+        }
+    }
 
     // MARK: - EventChannel.StreamHandler
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="light_compressor_v2_example"
+        android:label="light_compressor_v2"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/lib/batch_compress_view.dart
+++ b/example/lib/batch_compress_view.dart
@@ -36,6 +36,7 @@ class _BatchCompressViewState extends State<BatchCompressView>
   List<_Item> _items = <_Item>[];
   double _overall = 0;
   bool _running = false;
+  bool _runInBackground = false;
   StreamSubscription<BatchEvent>? _subscription;
 
   @override
@@ -96,6 +97,9 @@ class _BatchCompressViewState extends State<BatchCompressView>
         isMinBitrateCheckEnabled: false,
         android: AndroidConfig(isSharedStorage: true, saveAt: SaveAt.Movies),
         ios: IOSConfig(saveInGallery: false),
+        background: _runInBackground
+            ? const BackgroundConfig()
+            : null,
       );
     } catch (e) {
       debugPrint('Batch error: $e');
@@ -141,6 +145,17 @@ class _BatchCompressViewState extends State<BatchCompressView>
             onPressed: _running ? null : _pickAndCompress,
             icon: const Icon(Icons.video_library_outlined),
             label: const Text('Pick videos'),
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Run in background'),
+            subtitle: const Text(
+              'Keep compressing when the app is backgrounded or the screen is off',
+            ),
+            value: _runInBackground,
+            onChanged: _running
+                ? null
+                : (value) => setState(() => _runInBackground = value),
           ),
           if (_running) ...[
             const SizedBox(height: 16),

--- a/example/lib/single_compress_view.dart
+++ b/example/lib/single_compress_view.dart
@@ -31,6 +31,7 @@ class _SingleCompressViewState extends State<SingleCompressView>
   String? _thumbnailPath;
   OnSuccess? _result;
   String? _error;
+  bool _runInBackground = false;
 
   Future<void> _pickVideo() async {
     final result = await FilePicker.platform.pickFiles(type: FileType.video);
@@ -83,6 +84,7 @@ class _SingleCompressViewState extends State<SingleCompressView>
         video: Video(videoName: videoName),
         android: AndroidConfig(isSharedStorage: true, saveAt: SaveAt.Movies),
         ios: IOSConfig(saveInGallery: false),
+        background: _runInBackground ? const BackgroundConfig() : null,
       );
       if (!mounted) return;
       setState(() {
@@ -126,6 +128,17 @@ class _SingleCompressViewState extends State<SingleCompressView>
           onPressed: _stage == _Stage.compressing ? null : _pickVideo,
           icon: const Icon(Icons.video_call_outlined),
           label: const Text('Pick a video'),
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Run in background'),
+          subtitle: const Text(
+            'Keep compressing when the app is backgrounded or the screen is off',
+          ),
+          value: _runInBackground,
+          onChanged: _stage == _Stage.compressing
+              ? null
+              : (value) => setState(() => _runInBackground = value),
         ),
         if (_info != null || _thumbnailPath != null) ...[
           const SizedBox(height: 16),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -174,7 +174,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   lints:
     dependency: transitive
     description:

--- a/lib/light_compressor_v2.dart
+++ b/lib/light_compressor_v2.dart
@@ -1,4 +1,5 @@
 export 'src/android_config.dart';
+export 'src/background_config.dart';
 export 'src/batch_event.dart';
 export 'src/compression_result.dart';
 export 'src/exceptions.dart';

--- a/lib/src/background_config.dart
+++ b/lib/src/background_config.dart
@@ -1,0 +1,52 @@
+import 'package:light_compressor_v2/light_compressor_v2.dart';
+
+/// Keeps a compression running while the app is backgrounded or the screen is
+/// off.
+///
+/// Pass an instance to [LightCompressor.compressVideo] or
+/// [LightCompressor.compressVideos] through their `background` parameter to opt
+/// in. Leaving it `null` (the default) preserves the previous behaviour, where
+/// the OS may pause or terminate a long-running compression once the app
+/// leaves the foreground.
+///
+/// ## Platform behaviour
+///
+/// Background execution is constrained by each operating system, so the
+/// guarantees differ substantially:
+///
+/// * **Android** — the compression runs under a *foreground service*, surfaced
+///   to the user as an ongoing notification that shows live progress (bar +
+///   percentage), an elapsed-time timer, the current file or batch progress
+///   and a Cancel action. [notificationTitle] sets its
+///   title. This keeps the process at
+///   foreground priority, so compression continues uninterrupted when the app
+///   is backgrounded or the screen turns off.
+///   On Android 13+ the system notification requires the `POST_NOTIFICATIONS`
+///   permission; the plugin requests it automatically. If the user denies it,
+///   compression still runs — only the notification is hidden.
+///
+/// * **macOS** — App Nap is suppressed for the duration of the compression
+///   (via `NSProcessInfo.beginActivity`), so the process keeps full CPU while
+///   in the background. The notification fields are ignored.
+///
+/// * **iOS** — **not supported.** iOS suspends backgrounded apps within
+///   seconds, which freezes an in-process compression until the app returns to
+///   the foreground; there is no sanctioned way to keep video transcoding
+///   running in the background. Passing a [BackgroundConfig] on iOS therefore
+///   has no effect — the compression behaves exactly as it would without it.
+class BackgroundConfig {
+  /// Creates a configuration that enables background execution.
+  ///
+  /// The notification fields are used on Android only; other platforms ignore
+  /// them. Sensible English defaults are provided so the simplest opt-in is
+  /// `const BackgroundConfig()`.
+  const BackgroundConfig({this.notificationTitle = 'Compressing video'});
+
+  /// Android only — the title shown on the foreground-service notification.
+  final String notificationTitle;
+
+  /// Serialises this configuration into the map sent across the method channel.
+  Map<String, dynamic> toMap() => <String, dynamic>{
+    'notificationTitle': notificationTitle,
+  };
+}

--- a/lib/src/light_compressor.dart
+++ b/lib/src/light_compressor.dart
@@ -100,6 +100,10 @@ class LightCompressor {
   /// Optional Parameters:
   /// * [disableAudio] — If set to `true`, the audio track will be stripped, producing a silent video. Defaults to `false`.
   /// * [isMinBitrateCheckEnabled] — If `true`, the compressor checks if the source video's bitrate is above a minimum threshold (2 Mbps) before starting. If it's below the threshold, compression is skipped to prevent quality degradation. Defaults to `true`.
+  /// * [background] — When provided, keeps the compression running while the
+  ///   app is backgrounded or the screen is off. Behaviour and guarantees vary
+  ///   per platform; see [BackgroundConfig]. Defaults to `null` (the OS may
+  ///   pause/terminate the compression once the app leaves the foreground).
   ///
   /// Returns a [Result] which can be:
   /// * [OnSuccess] containing the output destination file path and statistics.
@@ -119,6 +123,7 @@ class LightCompressor {
     required Video video,
     bool? disableAudio = false,
     bool isMinBitrateCheckEnabled = true,
+    BackgroundConfig? background,
   }) async {
     final Map<String, dynamic> response = jsonDecode(
       await _channel
@@ -135,6 +140,7 @@ class LightCompressor {
             'videoWidth': video.videoWidth,
             'videoName': video.videoName,
             'saveInGallery': ios.saveInGallery,
+            'background': background?.toMap(),
           }),
     );
 
@@ -204,6 +210,10 @@ class LightCompressor {
   ///
   /// Subscribe to [onBatchUpdate] for per-video progress and completion events
   /// as the batch runs.
+  ///
+  /// When [background] is provided the whole batch keeps running while the app
+  /// is backgrounded or the screen is off; see [BackgroundConfig] for the
+  /// per-platform behaviour and caveats.
   Future<List<Result>> compressVideos({
     required List<String> paths,
     required List<String> videoNames,
@@ -216,6 +226,7 @@ class LightCompressor {
     int? videoBitrateInMbps,
     bool disableAudio = false,
     bool isMinBitrateCheckEnabled = true,
+    BackgroundConfig? background,
   }) async {
     assert(
       paths.length == videoNames.length,
@@ -239,6 +250,7 @@ class LightCompressor {
           'videoBitrateInMbps': videoBitrateInMbps,
           'disableAudio': disableAudio,
           'isMinBitrateCheckEnabled': isMinBitrateCheckEnabled,
+          'background': background?.toMap(),
         });
 
     if (response == null) {

--- a/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressorPlugin.swift
+++ b/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressorPlugin.swift
@@ -41,6 +41,12 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                 
                 let videoCompressor = LightCompressor()
                 
+                // Suppress App Nap while the app is backgrounded when the caller
+                // opted into background execution via BackgroundConfig.
+                let background: BackgroundExecution? =
+                    (myArgs["background"] as? [String: Any]) != nil ? BackgroundExecution() : nil
+                background?.begin()
+
                 // A FlutterResult may be delivered only once. Cancellation can
                 // race with completion, so funnel every terminal reply through
                 // this guard on the main thread.
@@ -49,6 +55,7 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                     DispatchQueue.main.async {
                         guard !didReply else { return }
                         didReply = true
+                        background?.end()
                         result(payload)
                     }
                 }
@@ -197,6 +204,12 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
         var percents = [Double](repeating: 0, count: count)
         var completed = 0
 
+        // Suppress App Nap for the whole batch when background execution was
+        // requested via BackgroundConfig.
+        let background: BackgroundExecution? =
+            (args["background"] as? [String: Any]) != nil ? BackgroundExecution() : nil
+        background?.begin()
+
         func record(_ index: Int, _ map: [String: Any]) {
             DispatchQueue.main.async {
                 guard index >= 0, index < count, results[index] == nil else { return }
@@ -207,6 +220,7 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                 event["index"] = index
                 self.batchStreamHandler.eventSink?(event)
                 if completed == count {
+                    background?.end()
                     result(results.map { $0 ?? ["onFailure": "Unknown error"] })
                 }
             }
@@ -370,5 +384,25 @@ final class BatchStreamHandler: NSObject, FlutterStreamHandler {
     func onCancel(withArguments arguments: Any?) -> FlutterError? {
         eventSink = nil
         return nil
+    }
+}
+
+/// Suppresses macOS App Nap while a compression runs so the process keeps full
+/// CPU when the app is in the background. Created only when a compression opts
+/// into background execution via `BackgroundConfig`; the notification fields of
+/// that config are ignored on macOS.
+final class BackgroundExecution {
+    private var token: NSObjectProtocol?
+
+    func begin() {
+        guard token == nil else { return }
+        token = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleSystemSleepDisabled],
+            reason: "Video compression")
+    }
+
+    func end() {
+        if let token { ProcessInfo.processInfo.endActivity(token) }
+        token = nil
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: light_compressor_v2
 description: A powerful and easy-to-use video compression plugin for Flutter.
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/Farid023/light_compressor_v2
 issue_tracker: https://github.com/Farid023/light_compressor_v2/issues
 

--- a/test/light_compressor_test.dart
+++ b/test/light_compressor_test.dart
@@ -91,6 +91,59 @@ void main() {
       },
     );
 
+    test('compressVideo forwards BackgroundConfig as a background map', () async {
+      mockedResponse = jsonEncode({'onSuccess': '/path/to/output.mp4'});
+
+      await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+        background: const BackgroundConfig(notificationTitle: 'Title'),
+      );
+
+      final arguments = log.first.arguments as Map<dynamic, dynamic>;
+      expect(arguments['background'], <String, dynamic>{
+        'notificationTitle': 'Title',
+      });
+    });
+
+    test('compressVideo sends a null background when not requested', () async {
+      mockedResponse = jsonEncode({'onSuccess': '/path/to/output.mp4'});
+
+      await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      final arguments = log.first.arguments as Map<dynamic, dynamic>;
+      expect(arguments.containsKey('background'), isTrue);
+      expect(arguments['background'], isNull);
+    });
+
+    test('compressVideos forwards BackgroundConfig defaults', () async {
+      batchResponse = <Map<String, dynamic>>[
+        {'onSuccess': '/out0.mp4'},
+      ];
+
+      await compressor.compressVideos(
+        paths: ['/a.mp4'],
+        videoNames: ['out0.mp4'],
+        videoQuality: VideoQuality.medium,
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+        background: const BackgroundConfig(),
+      );
+
+      final arguments = log.last.arguments as Map<dynamic, dynamic>;
+      final background = arguments['background'] as Map<dynamic, dynamic>;
+      expect(background['notificationTitle'], 'Compressing video');
+    });
+
     test('compressVideo returns OnSuccess when successful', () async {
       mockedResponse = jsonEncode({
         'onSuccess': '/path/to/output.mp4',


### PR DESCRIPTION
Opt-in per call via a new BackgroundConfig; keeps a compression running while the app is backgrounded or the screen is off.

- Dart: add BackgroundConfig (notificationTitle) and a background param on compressVideo/compressVideos; passing it enables background execution.
- Android: a foreground service anchors the process (no IPC, compression stays in-process). Notification shows a progress bar + percent, an elapsed-time chronometer, the current file (single) or a done/total count (batch), and an OS-localized Cancel action via a BroadcastReceiver. Declares the service, receiver and FGS/POST_NOTIFICATIONS permissions and requests POST_NOTIFICATIONS at runtime. Works on API 24-35.
- macOS: suppress App Nap (NSProcessInfo.beginActivity) for true background.
- iOS: not supported (the OS suspends backgrounded apps); BackgroundConfig is ignored and documented as such.
- Example: add a Run in background toggle to the single and batch screens.
- Bump to 1.3.0; update CHANGELOG and README.