### PR TITLE
Release/1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 1.4.0
+
+### New
+
+- **H.265 / HEVC output** — pass an optional `videoFormat` to `compressVideo` / `compressVideos` to choose the output codec (`VideoFormat.h264` — the default — or `VideoFormat.h265`). HEVC produces noticeably smaller files at comparable quality. Omitting the parameter keeps the previous H.264 behaviour and is fully backwards compatible.
+  - **Automatic fallback** — `VideoFormat.h265` is used only when the device can encode HEVC in hardware (Android: a non-software `video/hevc` encoder; iOS/macOS: an advertised HEVC encoder). On devices without it, the compressor transparently falls back to H.264 instead of failing.
+  - **`OnSuccess.usedFormat`** — every successful result now reports the codec actually used, so you can tell whether an H.265 request was honoured or fell back to H.264.
+- Example app gains a **“Use H.265 (HEVC)”** toggle in both the single and batch flows, and the single-video result now shows the codec used.
+
 # 1.3.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Extreme high bitrates are reduced while maintaining good video quality, resultin
 
 - **Single & batch compression** — compress one video, or many in a single call with per-item results and progress.
 - **Five quality presets** — the plugin calculates the optimal bitrate automatically.
+- **H.264 & H.265 (HEVC)** — pick the output codec via `videoFormat`; H.265 produces smaller files and automatically falls back to H.264 when the device can't encode it. `OnSuccess.usedFormat` reports the codec actually used.
 - **Custom resolution & bitrate** — override width, height, and bitrate when presets aren't enough.
 - **Structured success result** — `OnSuccess` carries `originalSize`, `compressedSize`, `duration`, and `ratio` (percentage reduction).
 - **Media info** — read width, height, duration, bitrate, rotation, frame rate, and MIME type via `getMediaInfo`.
@@ -173,6 +174,34 @@ Platform behaviour differs significantly:
   `BackgroundConfig` has no effect; the compression pauses and resumes when the
   app returns to the foreground.
 
+### Choose the output codec (H.265 / HEVC)
+
+By default the output is H.264 (AVC). Pass `videoFormat: VideoFormat.h265` to
+request HEVC, which yields smaller files at comparable quality. It applies to
+both `compressVideo` and `compressVideos`:
+
+```dart
+final result = await compressor.compressVideo(
+  path: '/path/to/source.mp4',
+  videoQuality: VideoQuality.medium,
+  videoFormat: VideoFormat.h265,
+  video: Video(videoName: 'compressed.mp4'),
+  android: AndroidConfig(saveAt: SaveAt.Movies),
+  ios: IOSConfig(saveInGallery: true),
+);
+
+if (result is OnSuccess) {
+  // Tells you whether H.265 was honoured or fell back to H.264.
+  print('Encoded with ${result.usedFormat.name}');
+}
+```
+
+`VideoFormat.h265` is used only when the device has a hardware HEVC encoder
+(Android excludes software-only encoders; iOS/macOS check the platform's
+advertised HEVC support). When it isn't available the compressor **silently
+falls back to H.264** rather than failing — always read `OnSuccess.usedFormat`
+to know what you got.
+
 ### Listen to progress
 
 Single video — a `Stream<double>` from `0` to `100`:
@@ -266,6 +295,7 @@ try {
 | `video` | `Video` | ✅ | — | Output video configuration (name, resolution, bitrate). |
 | `isMinBitrateCheckEnabled` | `bool` | | `true` | Skip compression when source bitrate is below 2 Mbps. |
 | `disableAudio` | `bool?` | | `false` | Strip the audio track from the output. |
+| `videoFormat` | `VideoFormat` | | `h264` | Output codec: `h264` or `h265` (HEVC). Falls back to H.264 when HEVC isn't supported. See [`VideoFormat`](#videoformat). |
 | `background` | `BackgroundConfig?` | | `null` | Keep running while the app is backgrounded. See [`BackgroundConfig`](#backgroundconfig). |
 
 ### `compressVideos()` → `Future<List<Result>>`
@@ -282,6 +312,7 @@ try {
 | `videoBitrateInMbps` | `int?` | | `null` | Custom bitrate in Mbps (overrides the preset). |
 | `disableAudio` | `bool` | | `false` | Strip the audio track from every output. |
 | `isMinBitrateCheckEnabled` | `bool` | | `true` | Skip compression when source bitrate is below 2 Mbps. |
+| `videoFormat` | `VideoFormat` | | `h264` | Output codec for every video: `h264` or `h265` (HEVC). See [`VideoFormat`](#videoformat). |
 | `background` | `BackgroundConfig?` | | `null` | Keep the whole batch running while backgrounded. See [`BackgroundConfig`](#backgroundconfig). |
 
 ### `Video`
@@ -315,11 +346,20 @@ Opt into background execution. `notificationTitle` is the Android foreground-ser
 |-----------|------|---------|-------------|
 | `notificationTitle` | `String` | `'Compressing video'` | Title of the Android foreground-service notification. |
 
+### `VideoFormat`
+
+Output codec, written into an MP4/QuickTime container.
+
+| Value | Description |
+|-------|-------------|
+| `h264` | H.264 / AVC. The widely compatible default. |
+| `h265` | H.265 / HEVC. Smaller files at comparable quality; **requires a hardware HEVC encoder** and automatically falls back to `h264` otherwise. Check [`OnSuccess.usedFormat`](#result-types) for the codec actually used. |
+
 ### `Result` types
 
 | Type | Properties | Description |
 |------|-----------|-------------|
-| `OnSuccess` | `destinationPath: String`, `originalSize: int`, `compressedSize: int`, `duration: double`, `ratio: double` | Output path, byte sizes, duration (seconds) and percentage size reduction. |
+| `OnSuccess` | `destinationPath: String`, `originalSize: int`, `compressedSize: int`, `duration: double`, `ratio: double`, `usedFormat: VideoFormat` | Output path, byte sizes, duration (seconds), percentage size reduction and the codec actually used. |
 | `OnFailure` | `message: String` | Unclassified failure with an error message. |
 | `OnCancelled` | `isCancelled: bool` | Compression was cancelled via `cancelCompression()`. |
 

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/LightCompressorPlugin.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/LightCompressorPlugin.kt
@@ -376,6 +376,7 @@ import java.io.FileOutputStream
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.CompressionErrorType
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.CompressionListener
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoCompressor
+import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoFormat
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoQuality
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.config.*
 import com.google.gson.Gson
@@ -499,26 +500,27 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
 
         val background = parseBackground(call)
         if (background != null) maybeRequestNotificationPermission()
+        val videoFormat = parseVideoFormat(call)
 
         if (isSharedStorage) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 requestPermissionAndCompress33(
                     path, result, quality, isMinBitrateCheckEnabled,
                     videoBitrateInMbps, disableAudio, resizer,
-                    storageConfiguration, videoName, background
+                    storageConfiguration, videoName, background, videoFormat
                 )
             } else {
                 requestPermissionAndCompressLegacy(
                     path, result, quality, isMinBitrateCheckEnabled,
                     videoBitrateInMbps, disableAudio, resizer,
-                    storageConfiguration, videoName, background
+                    storageConfiguration, videoName, background, videoFormat
                 )
             }
         } else {
             compressVideo(
                 path, result, quality, isMinBitrateCheckEnabled,
                 videoBitrateInMbps, disableAudio, resizer,
-                storageConfiguration, videoName, background
+                storageConfiguration, videoName, background, videoFormat
             )
         }
     }
@@ -536,6 +538,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         storageConfiguration: StorageConfiguration,
         videoName: String,
         background: BackgroundParams?,
+        videoFormat: VideoFormat,
     ) {
         val sourcePath = path
         // A MethodChannel reply may be submitted only once. A cancelled run can
@@ -566,6 +569,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                 disableAudio = disableAudio,
                 resizer = resizer,
                 videoNames = listOf(videoName),
+                videoFormat = videoFormat,
             ),
             listener = object : CompressionListener {
                 override fun onStart(index: Int) {}
@@ -581,7 +585,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                     }
                 }
 
-                override fun onSuccess(index: Int, size: Long, path: String?, duration: Double) {
+                override fun onSuccess(index: Int, size: Long, path: String?, duration: Double, videoFormat: String) {
                     val originalSize = try {
                         File(sourcePath).length()
                     } catch (e: Exception) {
@@ -592,7 +596,8 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                         "index" to index.toString(),
                         "duration" to duration,
                         "originalSize" to originalSize,
-                        "compressedSize" to size
+                        "compressedSize" to size,
+                        "usedFormat" to videoFormat
                     ))
                 }
 
@@ -704,6 +709,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                 disableAudio = disableAudio,
                 resizer = resizer,
                 videoNames = videoNames,
+                videoFormat = parseVideoFormat(call),
             ),
             listener = object : CompressionListener {
                 override fun onStart(index: Int) {}
@@ -729,7 +735,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                     }
                 }
 
-                override fun onSuccess(index: Int, size: Long, path: String?, duration: Double) {
+                override fun onSuccess(index: Int, size: Long, path: String?, duration: Double, videoFormat: String) {
                     val originalSize = try {
                         File(paths[index]).length()
                     } catch (e: Exception) {
@@ -739,7 +745,8 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
                         "onSuccess" to (path ?: ""),
                         "originalSize" to originalSize,
                         "compressedSize" to size,
-                        "duration" to duration
+                        "duration" to duration,
+                        "usedFormat" to videoFormat
                     ))
                 }
 
@@ -765,7 +772,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         isMinBitrateCheckEnabled: Boolean, videoBitrateInMbps: Int?,
         disableAudio: Boolean, resizer: VideoResizer?,
         storageConfiguration: StorageConfiguration, videoName: String,
-        background: BackgroundParams?
+        background: BackgroundParams?, videoFormat: VideoFormat
     ) {
         if (ContextCompat.checkSelfPermission(
                 activity, Manifest.permission.READ_MEDIA_VIDEO
@@ -784,7 +791,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         }
         compressVideo(
             path, result, quality, isMinBitrateCheckEnabled,
-            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background
+            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background, videoFormat
         )
     }
 
@@ -793,7 +800,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         isMinBitrateCheckEnabled: Boolean, videoBitrateInMbps: Int?,
         disableAudio: Boolean, resizer: VideoResizer?,
         storageConfiguration: StorageConfiguration, videoName: String,
-        background: BackgroundParams?
+        background: BackgroundParams?, videoFormat: VideoFormat
     ) {
         val permissions = arrayOf(
             Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -804,7 +811,7 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
         }
         compressVideo(
             path, result, quality, isMinBitrateCheckEnabled,
-            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background
+            videoBitrateInMbps, disableAudio, resizer, storageConfiguration, videoName, background, videoFormat
         )
     }
 
@@ -831,6 +838,13 @@ class LightCompressorPlugin : FlutterPlugin, MethodCallHandler,
             title = (map["notificationTitle"] as? String) ?: "Compressing video",
         )
     }
+
+    /** Parses the optional `videoFormat` argument; defaults to H.264. */
+    private fun parseVideoFormat(call: MethodCall): VideoFormat =
+        when (call.argument<String>("videoFormat")) {
+            "h265" -> VideoFormat.H265
+            else -> VideoFormat.H264
+        }
 
     /**
      * Requests the POST_NOTIFICATIONS runtime permission (Android 13+) so the

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/CompressionInterface.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/CompressionInterface.kt
@@ -31,7 +31,7 @@ interface CompressionListener {
     fun onStart(index: Int)
 
     @MainThread
-    fun onSuccess(index: Int, size: Long, path: String?, duration: Double)
+    fun onSuccess(index: Int, size: Long, path: String?, duration: Double, videoFormat: String)
 
     @MainThread
     fun onFailure(index: Int, failureMessage: String, errorType: CompressionErrorType = CompressionErrorType.UNKNOWN)

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/VideoCompressor.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/VideoCompressor.kt
@@ -26,6 +26,12 @@ enum class VideoQuality {
     VERY_HIGH, HIGH, MEDIUM, LOW, VERY_LOW
 }
 
+/** Output video codec. [H265] falls back to [H264] when no hardware HEVC
+ *  encoder is available on the device. */
+enum class VideoFormat {
+    H264, H265
+}
+
 object VideoCompressor : CoroutineScope by MainScope() {
 
     private val jobs = mutableListOf<Job>()
@@ -174,7 +180,7 @@ object VideoCompressor : CoroutineScope by MainScope() {
                                 shouldSave = true
                             )
 
-                            listener.onSuccess(i, result.size, savedFile?.path, result.duration)
+                            listener.onSuccess(i, result.size, savedFile?.path, result.duration, result.videoFormat)
                         } else {
                             try {
                                 if (finalDesFile?.exists() == true) finalDesFile.delete()

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/compressor/Compressor.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/compressor/Compressor.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import android.util.Log
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.CompressionErrorType
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.CompressionProgressListener
+import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoFormat
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.config.Configuration
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.CompressorUtils.findTrack
+import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.CompressorUtils.isHevcHardwareEncoderAvailable
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.CompressorUtils.getBitrate
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.CompressorUtils.hasQTI
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.CompressorUtils.prepareVideoHeight
@@ -32,6 +34,8 @@ object Compressor {
 
     // H.264 Advanced Video Coding
     private const val MIME_TYPE = "video/avc"
+    // H.265 High Efficiency Video Coding
+    private const val HEVC_MIME = "video/hevc"
     private const val MEDIACODEC_TIMEOUT_DEFAULT = 100L
 
     private const val INVALID_BITRATE =
@@ -242,6 +246,15 @@ object Compressor {
             else -> rotation
         }
 
+        // Decide the output codec. H.265 is used only when the caller asked for
+        // it AND the device exposes a hardware HEVC encoder; otherwise we fall
+        // back to H.264 so compatibility is never silently broken.
+        val outputMime =
+            if (configuration.videoFormat == VideoFormat.H265 && isHevcHardwareEncoderAvailable())
+                HEVC_MIME
+            else
+                MIME_TYPE
+
         return@withContext start(
             index,
             newWidth,
@@ -253,7 +266,8 @@ object Compressor {
             extractor,
             listener,
             duration,
-            rotation
+            rotation,
+            outputMime
         )
 
         } finally {
@@ -277,7 +291,8 @@ object Compressor {
         extractor: MediaExtractor,
         compressionProgressListener: CompressionProgressListener,
         duration: Long,
-        rotation: Int
+        rotation: Int,
+        outputMime: String
     ): Result {
 
         if (newWidth != 0 && newHeight != 0) {
@@ -308,7 +323,7 @@ object Compressor {
                 val inputFormat = extractor.getTrackFormat(videoIndex)
 
                 val outputFormat: MediaFormat =
-                    MediaFormat.createVideoFormat(MIME_TYPE, newWidth, newHeight)
+                    MediaFormat.createVideoFormat(outputMime, newWidth, newHeight)
                 //set output format
                 setOutputFileParameters(
                     inputFormat,
@@ -578,7 +593,8 @@ object Compressor {
                 failureMessage = null,
                 size = resultFile.length(),
                 path = resultFile.path,
-                duration = reportedDurationUs.toDouble() / 1000000.0
+                duration = reportedDurationUs.toDouble() / 1000000.0,
+                videoFormat = if (outputMime == HEVC_MIME) "h265" else "h264"
             )
         }
 
@@ -663,10 +679,12 @@ object Compressor {
     private fun prepareEncoder(outputFormat: MediaFormat, hasQTI: Boolean): MediaCodec {
         var encoder: MediaCodec? = null
         var lastException: Exception? = null
+        // The encoder must match the codec chosen for the output format (AVC/HEVC).
+        val mime = outputFormat.getString(MediaFormat.KEY_MIME) ?: MIME_TYPE
 
         // Attempt 1: Default configuration (Hardware, Profile, CBR mode)
         try {
-            encoder = MediaCodec.createEncoderByType(MIME_TYPE)
+            encoder = MediaCodec.createEncoderByType(mime)
             encoder.configure(outputFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
             return encoder
         } catch (e: Exception) {
@@ -679,7 +697,7 @@ object Compressor {
         val formatVBR = cloneFormat(outputFormat)
         formatVBR.setInteger(MediaFormat.KEY_BITRATE_MODE, MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR)
         try {
-            encoder = MediaCodec.createEncoderByType(MIME_TYPE)
+            encoder = MediaCodec.createEncoderByType(mime)
             encoder.configure(formatVBR, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
             return encoder
         } catch (e: Exception) {
@@ -691,7 +709,7 @@ object Compressor {
         // Attempt 3: Remove profile level (Baseline/Default fallback, VBR mode)
         val formatNoProfile = cloneFormat(formatVBR, listOf(MediaFormat.KEY_PROFILE, MediaFormat.KEY_LEVEL))
         try {
-            encoder = MediaCodec.createEncoderByType(MIME_TYPE)
+            encoder = MediaCodec.createEncoderByType(mime)
             encoder.configure(formatNoProfile, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
             return encoder
         } catch (e: Exception) {
@@ -700,8 +718,12 @@ object Compressor {
             try { encoder?.release() } catch (ignored: Exception) {}
         }
 
-        // Attempt 4: Fallback to Software Encoders (c2.android.avc.encoder or OMX.google.h264.encoder)
-        val softwareEncoderNames = listOf("c2.android.avc.encoder", "OMX.google.h264.encoder")
+        // Attempt 4: Fallback to Software Encoders (codec-specific names).
+        val softwareEncoderNames = if (mime == HEVC_MIME) {
+            listOf("c2.android.hevc.encoder", "OMX.google.hevc.encoder")
+        } else {
+            listOf("c2.android.avc.encoder", "OMX.google.h264.encoder")
+        }
         for (name in softwareEncoderNames) {
             try {
                 encoder = MediaCodec.createByCodecName(name)

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/config/Configuration.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/config/Configuration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoFormat
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.VideoQuality
 import com.gurfdev.light_compressor_v2.lightcompressorlibrary.utils.saveVideoInExternal
 import java.io.File
@@ -16,7 +17,8 @@ data class Configuration(
     var videoBitrateInMbps: Int? = null,
     var disableAudio: Boolean = false,
     val resizer: VideoResizer? = VideoResizer.auto,
-    var videoNames: List<String>
+    var videoNames: List<String>,
+    var videoFormat: VideoFormat = VideoFormat.H264,
 ) {
     @Deprecated("Use VideoResizer to override the output video dimensions.", ReplaceWith("Configuration(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, resizer = if (keepOriginalResolution) null else VideoResizer.auto, videoNames)"))
     constructor(

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/utils/CompressorUtils.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/utils/CompressorUtils.kt
@@ -93,7 +93,7 @@ object CompressorUtils {
                 }
                 // If no supported pair is found we deliberately leave profile/level unset
                 // and let the encoder choose its own defaults.
-            } else {
+            } else if (outputFormat.getString(MediaFormat.KEY_MIME) != "video/hevc") {
                 setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline)
             }
 
@@ -242,6 +242,25 @@ object CompressorUtils {
     }
 
     /**
+     * True when the device advertises a **hardware** HEVC (H.265) encoder.
+     *
+     * AOSP software HEVC encoders (`c2.android.*` / `OMX.google.*`) are excluded
+     * because they are far too slow to be practical for video compression; when
+     * only those are present the caller falls back to H.264. Vendor Codec2
+     * encoders (e.g. `c2.qti.*`, `c2.exynos.*`, `c2.mtk.*`) are hardware and pass
+     * this check.
+     */
+    fun isHevcHardwareEncoderAvailable(): Boolean =
+        runCatching {
+            MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos.any { codec ->
+                codec.isEncoder &&
+                    "video/hevc" in codec.supportedTypes &&
+                    !codec.name.contains("google", ignoreCase = true) &&
+                    !codec.name.contains("c2.android", ignoreCase = true)
+            }
+        }.getOrDefault(false)
+
+    /**
      * Get the highest profile level supported by the AVC encoder: High > Main > Baseline
      */
     /**
@@ -263,11 +282,17 @@ object CompressorUtils {
             .filter { codec -> codec.isEncoder && type in codec.supportedTypes }
             .mapNotNull { codec -> runCatching { codec.getCapabilitiesForType(type) }.getOrNull() }
 
-        val preferenceOrder = listOf(
-            MediaCodecInfo.CodecProfileLevel.AVCProfileHigh,
-            MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
-            MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
-        )
+        val preferenceOrder = if (type == "video/hevc") {
+            // HEVC Main covers 8-bit 4:2:0 video, which is what this surface
+            // pipeline produces.
+            listOf(MediaCodecInfo.CodecProfileLevel.HEVCProfileMain)
+        } else {
+            listOf(
+                MediaCodecInfo.CodecProfileLevel.AVCProfileHigh,
+                MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
+                MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
+            )
+        }
 
         for (profile in preferenceOrder) {
             var best: MediaCodecInfo.CodecProfileLevel? = null

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/video/OutputSurface.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/video/OutputSurface.kt
@@ -63,12 +63,16 @@ class OutputSurface : OnFrameAvailableListener {
      * data is available.
      */
     fun awaitNewImage() {
-        val timeOutMS = 100
+        // Matches the upstream MediaCodec sample (bigflake). The previous 100ms was
+        // too aggressive: under a saturated GPU — e.g. several parallel 4K / HEVC
+        // sessions in a batch — the decoder can take longer than that to render a
+        // frame, and timing out drops it and corrupts the output. 2.5s tolerates
+        // heavy contention while still bailing out on a genuine stall.
+        val timeOutMS = 2500
         synchronized(mFrameSyncObject) {
             while (!mFrameAvailable) {
                 try {
-                    // Wait for onFrameAvailable() to signal us.  Use a timeout to avoid
-                    // stalling the test if it doesn't arrive.
+                    // Wait for onFrameAvailable() to signal us.
                     mFrameSyncObject.wait(timeOutMS.toLong())
                     if (!mFrameAvailable) {
                         throw RuntimeException("Surface frame wait timed out")

--- a/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/video/Result.kt
+++ b/android/src/main/kotlin/com/gurfdev/light_compressor_v2/lightcompressorlibrary/video/Result.kt
@@ -13,4 +13,7 @@ data class Result(
     /** True when the run was stopped by [VideoCompressor.cancel], so the caller
      *  can deliver onCancelled instead of treating it as a failure. */
     val cancelled: Boolean = false,
+    /** Codec actually used for the output: "h264" or "h265". H.265 falls back to
+     *  H.264 when the device has no hardware HEVC encoder. */
+    val videoFormat: String = "h264",
 )

--- a/example/lib/batch_compress_view.dart
+++ b/example/lib/batch_compress_view.dart
@@ -37,6 +37,7 @@ class _BatchCompressViewState extends State<BatchCompressView>
   double _overall = 0;
   bool _running = false;
   bool _runInBackground = false;
+  VideoFormat _videoFormat = VideoFormat.h264;
   StreamSubscription<BatchEvent>? _subscription;
 
   @override
@@ -97,6 +98,7 @@ class _BatchCompressViewState extends State<BatchCompressView>
         isMinBitrateCheckEnabled: false,
         android: AndroidConfig(isSharedStorage: true, saveAt: SaveAt.Movies),
         ios: IOSConfig(saveInGallery: false),
+        videoFormat: _videoFormat,
         background: _runInBackground
             ? const BackgroundConfig()
             : null,
@@ -156,6 +158,20 @@ class _BatchCompressViewState extends State<BatchCompressView>
             onChanged: _running
                 ? null
                 : (value) => setState(() => _runInBackground = value),
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Use H.265 (HEVC)'),
+            subtitle: const Text(
+              'Smaller files where supported; falls back to H.264 otherwise',
+            ),
+            value: _videoFormat == VideoFormat.h265,
+            onChanged: _running
+                ? null
+                : (value) => setState(
+                    () => _videoFormat =
+                        value ? VideoFormat.h265 : VideoFormat.h264,
+                  ),
           ),
           if (_running) ...[
             const SizedBox(height: 16),

--- a/example/lib/single_compress_view.dart
+++ b/example/lib/single_compress_view.dart
@@ -32,6 +32,7 @@ class _SingleCompressViewState extends State<SingleCompressView>
   OnSuccess? _result;
   String? _error;
   bool _runInBackground = false;
+  VideoFormat _videoFormat = VideoFormat.h264;
 
   Future<void> _pickVideo() async {
     final result = await FilePicker.platform.pickFiles(type: FileType.video);
@@ -84,6 +85,7 @@ class _SingleCompressViewState extends State<SingleCompressView>
         video: Video(videoName: videoName),
         android: AndroidConfig(isSharedStorage: true, saveAt: SaveAt.Movies),
         ios: IOSConfig(saveInGallery: false),
+        videoFormat: _videoFormat,
         background: _runInBackground ? const BackgroundConfig() : null,
       );
       if (!mounted) return;
@@ -139,6 +141,20 @@ class _SingleCompressViewState extends State<SingleCompressView>
           onChanged: _stage == _Stage.compressing
               ? null
               : (value) => setState(() => _runInBackground = value),
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Use H.265 (HEVC)'),
+          subtitle: const Text(
+            'Smaller files where supported; falls back to H.264 otherwise',
+          ),
+          value: _videoFormat == VideoFormat.h265,
+          onChanged: _stage == _Stage.compressing
+              ? null
+              : (value) => setState(
+                  () =>
+                      _videoFormat = value ? VideoFormat.h265 : VideoFormat.h264,
+                ),
         ),
         if (_info != null || _thumbnailPath != null) ...[
           const SizedBox(height: 16),
@@ -345,6 +361,9 @@ class _ResultCard extends StatelessWidget {
               Text('Original: ${formatBytes(result.originalSize, 2)}'),
               Text('Compressed: ${formatBytes(result.compressedSize, 2)}'),
               Text('Reduction: ${result.ratio.toStringAsFixed(1)}%'),
+              Text(
+                'Codec: ${result.usedFormat == VideoFormat.h265 ? 'H.265 (HEVC)' : 'H.264 (AVC)'}',
+              ),
               Text(
                 'Duration: ${formatDuration(Duration(milliseconds: (result.duration * 1000).round()))}',
               ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -174,7 +174,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   lints:
     dependency: transitive
     description:

--- a/ios/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
+++ b/ios/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
@@ -10,12 +10,29 @@ public enum VideoQuality {
     case very_low
 }
 
+/// The output video codec used for compression.
+public enum VideoFormat {
+    /// H.264 / AVC — the widely compatible default.
+    case h264
+    /// H.265 / HEVC — smaller files at the same quality; requires hardware
+    /// support, otherwise the compressor falls back to `.h264`.
+    case h265
+
+    /// Lower-case wire value shared with Dart (`"h264"` / `"h265"`).
+    var wireValue: String { self == .h265 ? "h265" : "h264" }
+
+    /// Maps a Dart wire value back to a format; defaults to `.h264`.
+    static func from(wire: String?) -> VideoFormat { wire == "h265" ? .h265 : .h264 }
+}
+
 /// The result of a compression operation.
 public enum CompressionResult {
     /// Compression has started.
     case onStart
-    /// Compression succeeded. Contains the video index, output URL, and video duration in seconds.
-    case onSuccess(Int, URL, Double)
+    /// Compression succeeded. Contains the video index, output URL, video
+    /// duration in seconds, and the codec actually used (which may differ from
+    /// the requested one if H.265 fell back to H.264).
+    case onSuccess(Int, URL, Double, VideoFormat)
     /// Compression failed. Contains the video index and error.
     case onFailure(Int, CompressionError)
     /// Compression was cancelled by the user.
@@ -98,6 +115,7 @@ public struct LightCompressor {
             public let disableAudio: Bool
             public let keepOriginalResolution: Bool
             public let videoSize: CGSize?
+            public let videoFormat: VideoFormat
 
             public init(
                 quality: VideoQuality = .medium,
@@ -105,7 +123,8 @@ public struct LightCompressor {
                 videoBitrateInMbps: Int? = nil,
                 disableAudio: Bool = false,
                 keepOriginalResolution: Bool = false,
-                videoSize: CGSize? = nil
+                videoSize: CGSize? = nil,
+                videoFormat: VideoFormat = .h264
             ) {
                 self.quality = quality
                 self.isMinBitrateCheckEnabled = isMinBitrateCheckEnabled
@@ -113,6 +132,7 @@ public struct LightCompressor {
                 self.disableAudio = disableAudio
                 self.keepOriginalResolution = keepOriginalResolution
                 self.videoSize = videoSize
+                self.videoFormat = videoFormat
             }
         }
 
@@ -333,13 +353,19 @@ public struct LightCompressor {
             let totalFrames       = ceil(durationInSeconds * Double(frameRate))
             let progress          = Progress(totalUnitCount: Int64(totalFrames))
 
+            // Resolve the output codec: use H.265 only when requested AND the
+            // device supports HEVC encoding; otherwise fall back to H.264.
+            let resolvedFormat: VideoFormat =
+                (configuration.videoFormat == .h265 && Self.isHEVCEncodingSupported()) ? .h265 : .h264
+
             // Video writer
             let videoWriterInput = AVAssetWriterInput(
                 mediaType: .video,
                 outputSettings: getVideoWriterSettings(
                     bitrate: newBitrate,
                     width: size.width,
-                    height: size.height))
+                    height: size.height,
+                    format: resolvedFormat))
             videoWriterInput.expectsMediaDataInRealTime = true
             videoWriterInput.transform = videoTrack.preferredTransform
 
@@ -438,7 +464,7 @@ public struct LightCompressor {
                                         audioWriterInput.markAsFinished()
                                         videoWriter.finishWriting {
                                             DispatchQueue.main.async {
-                                                completion(.onSuccess(index, destination, durationInSeconds))
+                                                completion(.onSuccess(index, destination, durationInSeconds, resolvedFormat))
                                             }
                                         }
                                     }
@@ -447,7 +473,7 @@ public struct LightCompressor {
                         } else {
                             videoWriter.finishWriting {
                                 DispatchQueue.main.async {
-                                    completion(.onSuccess(index, destination, durationInSeconds))
+                                    completion(.onSuccess(index, destination, durationInSeconds, resolvedFormat))
                                 }
                             }
                         }
@@ -505,12 +531,20 @@ public struct LightCompressor {
         return (newWidth, newHeight)
     }
 
-    private func getVideoWriterSettings(bitrate: Int, width: Int, height: Int) -> [String: AnyObject] {
+    /// Whether this device supports hardware HEVC (H.265) **encoding**. The
+    /// platform's advertised export presets include the HEVC presets only when
+    /// an HEVC encoder is available, which makes this a reliable capability probe.
+    private static func isHEVCEncodingSupported() -> Bool {
+        AVAssetExportSession.allExportPresets().contains(AVAssetExportPresetHEVCHighestQuality)
+    }
+
+    private func getVideoWriterSettings(bitrate: Int, width: Int, height: Int, format: VideoFormat) -> [String: AnyObject] {
         let compressionSettings: [String: AnyObject] = [
             AVVideoAverageBitRateKey: bitrate as AnyObject
         ]
+        let codec: AVVideoCodecType = (format == .h265) ? .hevc : .h264
         return [
-            AVVideoCodecKey:                  AVVideoCodecType.h264 as AnyObject,
+            AVVideoCodecKey:                  codec as AnyObject,
             AVVideoCompressionPropertiesKey:  compressionSettings as AnyObject,
             AVVideoWidthKey:                  width  as AnyObject,
             AVVideoHeightKey:                 height as AnyObject,

--- a/ios/light_compressor_v2/Sources/light_compressor_v2/SwiftLightCompressorPlugin.swift
+++ b/ios/light_compressor_v2/Sources/light_compressor_v2/SwiftLightCompressorPlugin.swift
@@ -112,6 +112,8 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
             }
         }
 
+        let videoFormat = VideoFormat.from(wire: args["videoFormat"] as? String)
+
         compression = LightCompressor().compressVideo(
             videos: [
                 .init(
@@ -123,7 +125,8 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
                         videoBitrateInMbps: videoBitrateInMbps,
                         disableAudio: disableAudio,
                         keepOriginalResolution: keepOriginalResolution,
-                        videoSize: videoSize))
+                        videoSize: videoSize,
+                        videoFormat: videoFormat))
             ],
             progressQueue: .main,
             progressHandler: { [weak self] _, progress in
@@ -139,7 +142,7 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
                 case .onStart:
                     break
 
-                case .onSuccess(let index, let url, let duration):
+                case .onSuccess(let index, let url, let duration, let usedFormat):
                     if saveInGallery {
                         PHPhotoLibrary.shared().performChanges {
                             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
@@ -155,13 +158,15 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
                         let duration: Double
                         let originalSize: Int
                         let compressedSize: Int
+                        let usedFormat: String
                     }
                     let response = SuccessResponse(
                         onSuccess: url.path,
                         index: String(index),
                         duration: duration,
                         originalSize: originalSize,
-                        compressedSize: compressedSize
+                        compressedSize: compressedSize,
+                        usedFormat: usedFormat.wireValue
                     )
                     replyOnce(response.toJson)
 
@@ -217,7 +222,8 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
             videoBitrateInMbps: videoBitrateInMbps,
             disableAudio: disableAudio,
             keepOriginalResolution: keepOriginalResolution,
-            videoSize: videoSize)
+            videoSize: videoSize,
+            videoFormat: VideoFormat.from(wire: args["videoFormat"] as? String))
 
         let count = paths.count
         var videos: [LightCompressor.Video] = []
@@ -273,7 +279,7 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
                 case .onStart:
                     break
 
-                case .onSuccess(let index, let url, let duration):
+                case .onSuccess(let index, let url, let duration, let usedFormat):
                     if saveInGallery {
                         PHPhotoLibrary.shared().performChanges {
                             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
@@ -288,6 +294,7 @@ public class SwiftLightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamH
                         "originalSize": originalSize,
                         "compressedSize": compressedSize,
                         "duration": duration,
+                        "usedFormat": usedFormat.wireValue,
                     ])
 
                 case .onFailure(let index, let error):

--- a/lib/light_compressor_v2.dart
+++ b/lib/light_compressor_v2.dart
@@ -7,3 +7,4 @@ export 'src/ios_config.dart';
 export 'src/light_compressor.dart';
 export 'src/media_info.dart';
 export 'src/video.dart';
+export 'src/video_format.dart';

--- a/lib/src/compression_result.dart
+++ b/lib/src/compression_result.dart
@@ -1,3 +1,5 @@
+import 'package:light_compressor_v2/light_compressor_v2.dart';
+
 /// Base class for video compression results.
 abstract class Result {}
 
@@ -10,6 +12,7 @@ class OnSuccess implements Result {
     required this.compressedSize,
     required this.duration,
     required this.ratio,
+    this.usedFormat = VideoFormat.h264,
   });
 
   /// The absolute path to the successfully compressed video file.
@@ -26,6 +29,14 @@ class OnSuccess implements Result {
 
   /// The percentage of size reduction.
   final double ratio;
+
+  /// The codec actually used to encode the output.
+  ///
+  /// Normally matches the requested `videoFormat`. When [VideoFormat.h265] was
+  /// requested but the device has no HEVC encoding support, the compressor
+  /// falls back to [VideoFormat.h264] and this field reflects that real
+  /// outcome. Defaults to [VideoFormat.h264].
+  final VideoFormat usedFormat;
 }
 
 /// Represents a failed video compression attempt.

--- a/lib/src/light_compressor.dart
+++ b/lib/src/light_compressor.dart
@@ -100,6 +100,11 @@ class LightCompressor {
   /// Optional Parameters:
   /// * [disableAudio] — If set to `true`, the audio track will be stripped, producing a silent video. Defaults to `false`.
   /// * [isMinBitrateCheckEnabled] — If `true`, the compressor checks if the source video's bitrate is above a minimum threshold (2 Mbps) before starting. If it's below the threshold, compression is skipped to prevent quality degradation. Defaults to `true`.
+  /// * [videoFormat] — The output codec. Defaults to [VideoFormat.h264].
+  ///   Requesting [VideoFormat.h265] (HEVC) yields smaller files but requires
+  ///   hardware support; on devices without it the compressor automatically
+  ///   falls back to H.264. The format actually used is reported by
+  ///   [OnSuccess.usedFormat].
   /// * [background] — When provided, keeps the compression running while the
   ///   app is backgrounded or the screen is off. Behaviour and guarantees vary
   ///   per platform; see [BackgroundConfig]. Defaults to `null` (the OS may
@@ -123,6 +128,7 @@ class LightCompressor {
     required Video video,
     bool? disableAudio = false,
     bool isMinBitrateCheckEnabled = true,
+    VideoFormat videoFormat = VideoFormat.h264,
     BackgroundConfig? background,
   }) async {
     final Map<String, dynamic> response = jsonDecode(
@@ -140,6 +146,7 @@ class LightCompressor {
             'videoWidth': video.videoWidth,
             'videoName': video.videoName,
             'saveInGallery': ios.saveInGallery,
+            'videoFormat': videoFormat.name,
             'background': background?.toMap(),
           }),
     );
@@ -178,6 +185,7 @@ class LightCompressor {
         compressedSize: compressedSize,
         duration: duration,
         ratio: ratio,
+        usedFormat: _videoFormatFromWire(response['usedFormat'] as String?),
       );
     } else if (response['onFailure'] != null) {
       final String failureMessage = response['onFailure'] as String;
@@ -211,6 +219,9 @@ class LightCompressor {
   /// Subscribe to [onBatchUpdate] for per-video progress and completion events
   /// as the batch runs.
   ///
+  /// [videoFormat] selects the output codec for every video (defaults to
+  /// [VideoFormat.h264]); see [compressVideo] for the H.265 fallback behaviour.
+  ///
   /// When [background] is provided the whole batch keeps running while the app
   /// is backgrounded or the screen is off; see [BackgroundConfig] for the
   /// per-platform behaviour and caveats.
@@ -226,6 +237,7 @@ class LightCompressor {
     int? videoBitrateInMbps,
     bool disableAudio = false,
     bool isMinBitrateCheckEnabled = true,
+    VideoFormat videoFormat = VideoFormat.h264,
     BackgroundConfig? background,
   }) async {
     assert(
@@ -250,6 +262,7 @@ class LightCompressor {
           'videoBitrateInMbps': videoBitrateInMbps,
           'disableAudio': disableAudio,
           'isMinBitrateCheckEnabled': isMinBitrateCheckEnabled,
+          'videoFormat': videoFormat.name,
           'background': background?.toMap(),
         });
 
@@ -282,6 +295,7 @@ class LightCompressor {
         compressedSize: compressedSize,
         duration: duration,
         ratio: ratio,
+        usedFormat: _videoFormatFromWire(map['usedFormat'] as String?),
       );
     } else if (map['onFailure'] != null) {
       return OnFailure(map['onFailure'] as String);
@@ -290,6 +304,12 @@ class LightCompressor {
     }
     return const OnFailure('Something went wrong');
   }
+
+  /// Maps the native `usedFormat` wire value (`"h264"` / `"h265"`) onto a
+  /// [VideoFormat]. Defaults to [VideoFormat.h264] when absent (older native
+  /// builds or platforms that do not report it).
+  VideoFormat _videoFormatFromWire(String? wire) =>
+      wire == 'h265' ? VideoFormat.h265 : VideoFormat.h264;
 
   /// Maps a native failure to a typed exception.
   ///

--- a/lib/src/video_format.dart
+++ b/lib/src/video_format.dart
@@ -1,0 +1,28 @@
+import 'package:light_compressor_v2/light_compressor_v2.dart';
+
+/// The output video codec used for compression.
+///
+/// Pass to [LightCompressor.compressVideo] / [LightCompressor.compressVideos]
+/// through their `videoFormat` parameter. Defaults to [VideoFormat.h264], which
+/// preserves the previous behaviour and is the safest, most compatible choice.
+///
+/// Both formats are written into an MP4/QuickTime container; only the video
+/// codec changes.
+enum VideoFormat {
+  /// H.264 / AVC — the widely compatible default, encodable and playable on
+  /// virtually every device.
+  h264,
+
+  /// H.265 / HEVC — roughly the same visual quality at a smaller file size, but
+  /// it requires a hardware HEVC encoder on the device.
+  ///
+  /// When [h265] is requested on a device (or platform) without HEVC encoding
+  /// support, the compressor automatically falls back to [h264]; the format
+  /// that was actually used is reported by [OnSuccess.usedFormat].
+  ///
+  /// Background by platform:
+  /// * **Android** — used only when a hardware HEVC encoder is present;
+  ///   software-only HEVC is treated as unsupported and falls back to H.264.
+  /// * **iOS / macOS** — used when the device advertises HEVC encoding support.
+  h265,
+}

--- a/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
+++ b/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
@@ -10,12 +10,29 @@ public enum VideoQuality {
     case very_low
 }
 
+/// The output video codec used for compression.
+public enum VideoFormat {
+    /// H.264 / AVC — the widely compatible default.
+    case h264
+    /// H.265 / HEVC — smaller files at the same quality; requires hardware
+    /// support, otherwise the compressor falls back to `.h264`.
+    case h265
+
+    /// Lower-case wire value shared with Dart (`"h264"` / `"h265"`).
+    var wireValue: String { self == .h265 ? "h265" : "h264" }
+
+    /// Maps a Dart wire value back to a format; defaults to `.h264`.
+    static func from(wire: String?) -> VideoFormat { wire == "h265" ? .h265 : .h264 }
+}
+
 /// The result of a compression operation.
 public enum CompressionResult {
     /// Compression has started.
     case onStart
-    /// Compression succeeded. Contains the video index, output URL, and video duration in seconds.
-    case onSuccess(Int, URL, Double)
+    /// Compression succeeded. Contains the video index, output URL, video
+    /// duration in seconds, and the codec actually used (which may differ from
+    /// the requested one if H.265 fell back to H.264).
+    case onSuccess(Int, URL, Double, VideoFormat)
     /// Compression failed. Contains the video index and error.
     case onFailure(Int, CompressionError)
     /// Compression was cancelled by the user.
@@ -98,6 +115,7 @@ public struct LightCompressor {
             public let disableAudio: Bool
             public let keepOriginalResolution: Bool
             public let videoSize: CGSize?
+            public let videoFormat: VideoFormat
 
             public init(
                 quality: VideoQuality = .medium,
@@ -105,7 +123,8 @@ public struct LightCompressor {
                 videoBitrateInMbps: Int? = nil,
                 disableAudio: Bool = false,
                 keepOriginalResolution: Bool = false,
-                videoSize: CGSize? = nil
+                videoSize: CGSize? = nil,
+                videoFormat: VideoFormat = .h264
             ) {
                 self.quality = quality
                 self.isMinBitrateCheckEnabled = isMinBitrateCheckEnabled
@@ -113,6 +132,7 @@ public struct LightCompressor {
                 self.disableAudio = disableAudio
                 self.keepOriginalResolution = keepOriginalResolution
                 self.videoSize = videoSize
+                self.videoFormat = videoFormat
             }
         }
 
@@ -333,13 +353,19 @@ public struct LightCompressor {
             let totalFrames       = ceil(durationInSeconds * Double(frameRate))
             let progress          = Progress(totalUnitCount: Int64(totalFrames))
 
+            // Resolve the output codec: use H.265 only when requested AND the
+            // device supports HEVC encoding; otherwise fall back to H.264.
+            let resolvedFormat: VideoFormat =
+                (configuration.videoFormat == .h265 && Self.isHEVCEncodingSupported()) ? .h265 : .h264
+
             // Video writer
             let videoWriterInput = AVAssetWriterInput(
                 mediaType: .video,
                 outputSettings: getVideoWriterSettings(
                     bitrate: newBitrate,
                     width: size.width,
-                    height: size.height))
+                    height: size.height,
+                    format: resolvedFormat))
             videoWriterInput.expectsMediaDataInRealTime = true
             videoWriterInput.transform = videoTrack.preferredTransform
 
@@ -438,7 +464,7 @@ public struct LightCompressor {
                                         audioWriterInput.markAsFinished()
                                         videoWriter.finishWriting {
                                             DispatchQueue.main.async {
-                                                completion(.onSuccess(index, destination, durationInSeconds))
+                                                completion(.onSuccess(index, destination, durationInSeconds, resolvedFormat))
                                             }
                                         }
                                     }
@@ -447,7 +473,7 @@ public struct LightCompressor {
                         } else {
                             videoWriter.finishWriting {
                                 DispatchQueue.main.async {
-                                    completion(.onSuccess(index, destination, durationInSeconds))
+                                    completion(.onSuccess(index, destination, durationInSeconds, resolvedFormat))
                                 }
                             }
                         }
@@ -505,12 +531,20 @@ public struct LightCompressor {
         return (newWidth, newHeight)
     }
 
-    private func getVideoWriterSettings(bitrate: Int, width: Int, height: Int) -> [String: AnyObject] {
+    /// Whether this device supports hardware HEVC (H.265) **encoding**. The
+    /// platform's advertised export presets include the HEVC presets only when
+    /// an HEVC encoder is available, which makes this a reliable capability probe.
+    private static func isHEVCEncodingSupported() -> Bool {
+        AVAssetExportSession.allExportPresets().contains(AVAssetExportPresetHEVCHighestQuality)
+    }
+
+    private func getVideoWriterSettings(bitrate: Int, width: Int, height: Int, format: VideoFormat) -> [String: AnyObject] {
         let compressionSettings: [String: AnyObject] = [
             AVVideoAverageBitRateKey: bitrate as AnyObject
         ]
+        let codec: AVVideoCodecType = (format == .h265) ? .hevc : .h264
         return [
-            AVVideoCodecKey:                  AVVideoCodecType.h264 as AnyObject,
+            AVVideoCodecKey:                  codec as AnyObject,
             AVVideoCompressionPropertiesKey:  compressionSettings as AnyObject,
             AVVideoWidthKey:                  width  as AnyObject,
             AVVideoHeightKey:                 height as AnyObject,

--- a/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressorPlugin.swift
+++ b/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressorPlugin.swift
@@ -70,7 +70,8 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                             videoBitrateInMbps: videoBitrateInMbps,
                             disableAudio: disableAudio,
                             keepOriginalResolution: keepOriginalResolution,
-                            videoSize: videoWidth == nil || videoHeight == nil ? nil : CGSize(width: videoWidth!, height: videoHeight!))
+                            videoSize: videoWidth == nil || videoHeight == nil ? nil : CGSize(width: videoWidth!, height: videoHeight!),
+                            videoFormat: VideoFormat.from(wire: myArgs["videoFormat"] as? String))
                     )],
                     progressQueue: .main,
                     progressHandler: { _, progress in
@@ -86,7 +87,7 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                     completion: { compressionResult in
                         
                         switch compressionResult {
-                        case .onSuccess(let index, let outputURL, let duration):
+                        case .onSuccess(let index, let outputURL, let duration, let usedFormat):
                             if(saveInGallery) {
                                 DispatchQueue.main.async {
                                     PHPhotoLibrary.shared().performChanges({
@@ -104,13 +105,15 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                                 let duration: Double
                                 let originalSize: Int
                                 let compressedSize: Int
+                                let usedFormat: String
                             }
                             let response = SuccessResponse(
                                 onSuccess: outputURL.path,
                                 index: String(index),
                                 duration: duration,
                                 originalSize: originalSize,
-                                compressedSize: compressedSize
+                                compressedSize: compressedSize,
+                                usedFormat: usedFormat.wireValue
                             )
                             replyOnce(response.toJson)
                             
@@ -186,7 +189,8 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
             videoBitrateInMbps: videoBitrateInMbps,
             disableAudio: disableAudio,
             keepOriginalResolution: keepOriginalResolution,
-            videoSize: videoSize)
+            videoSize: videoSize,
+            videoFormat: VideoFormat.from(wire: args["videoFormat"] as? String))
 
         let count = paths.count
         var videos: [LightCompressor.Video] = []
@@ -247,7 +251,7 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                 case .onStart:
                     break
 
-                case .onSuccess(let index, let outputURL, let duration):
+                case .onSuccess(let index, let outputURL, let duration, let usedFormat):
                     if saveInGallery {
                         DispatchQueue.main.async {
                             PHPhotoLibrary.shared().performChanges {
@@ -264,6 +268,7 @@ public class LightCompressorPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                         "originalSize": originalSize,
                         "compressedSize": compressedSize,
                         "duration": duration,
+                        "usedFormat": usedFormat.wireValue,
                     ])
 
                 case .onFailure(let index, let error):

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: light_compressor_v2
 description: A powerful and easy-to-use video compression plugin for Flutter.
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/Farid023/light_compressor_v2
 issue_tracker: https://github.com/Farid023/light_compressor_v2/issues
 

--- a/test/light_compressor_test.dart
+++ b/test/light_compressor_test.dart
@@ -144,6 +144,89 @@ void main() {
       expect(background['notificationTitle'], 'Compressing video');
     });
 
+    test('compressVideo forwards videoFormat (defaults to h264)', () async {
+      mockedResponse = jsonEncode({'onSuccess': '/path/to/output.mp4'});
+
+      await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      final arguments = log.first.arguments as Map<dynamic, dynamic>;
+      expect(arguments['videoFormat'], 'h264');
+    });
+
+    test('compressVideo forwards videoFormat h265 when requested', () async {
+      mockedResponse = jsonEncode({'onSuccess': '/path/to/output.mp4'});
+
+      await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        videoFormat: VideoFormat.h265,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      final arguments = log.first.arguments as Map<dynamic, dynamic>;
+      expect(arguments['videoFormat'], 'h265');
+    });
+
+    test('compressVideo parses usedFormat into OnSuccess', () async {
+      mockedResponse = jsonEncode({
+        'onSuccess': '/path/to/output.mp4',
+        'usedFormat': 'h265',
+      });
+
+      final result = await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        videoFormat: VideoFormat.h265,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      expect(result, isA<OnSuccess>());
+      expect((result as OnSuccess).usedFormat, VideoFormat.h265);
+    });
+
+    test('compressVideo defaults usedFormat to h264 when absent', () async {
+      mockedResponse = jsonEncode({'onSuccess': '/path/to/output.mp4'});
+
+      final result = await compressor.compressVideo(
+        path: '/path/to/input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'output.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      expect((result as OnSuccess).usedFormat, VideoFormat.h264);
+    });
+
+    test('compressVideos forwards videoFormat and parses usedFormat', () async {
+      batchResponse = <Map<String, dynamic>>[
+        {'onSuccess': '/out0.mp4', 'usedFormat': 'h265'},
+      ];
+
+      final results = await compressor.compressVideos(
+        paths: ['/a.mp4'],
+        videoNames: ['out0.mp4'],
+        videoQuality: VideoQuality.medium,
+        videoFormat: VideoFormat.h265,
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      final arguments = log.last.arguments as Map<dynamic, dynamic>;
+      expect(arguments['videoFormat'], 'h265');
+      expect((results.first as OnSuccess).usedFormat, VideoFormat.h265);
+    });
+
     test('compressVideo returns OnSuccess when successful', () async {
       mockedResponse = jsonEncode({
         'onSuccess': '/path/to/output.mp4',

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -71,6 +71,20 @@ void main() {
       expect(result.compressedSize, 500);
       expect(result.duration, 10.0);
       expect(result.ratio, 50.0);
+      // Defaults to H.264 when not specified.
+      expect(result.usedFormat, VideoFormat.h264);
+    });
+
+    test('OnSuccess carries the codec actually used', () {
+      const result = OnSuccess(
+        destinationPath: '/path/to/video.mp4',
+        originalSize: 1000,
+        compressedSize: 500,
+        duration: 10.0,
+        ratio: 50.0,
+        usedFormat: VideoFormat.h265,
+      );
+      expect(result.usedFormat, VideoFormat.h265);
     });
 
     test('OnFailure contains message', () {


### PR DESCRIPTION
# 1.4.0

### New

- **H.265 / HEVC output** — pass an optional `videoFormat` to `compressVideo` / `compressVideos` to choose the output codec (`VideoFormat.h264` — the default — or `VideoFormat.h265`). HEVC produces noticeably smaller files at comparable quality. Omitting the parameter keeps the previous H.264 behaviour and is fully backwards compatible.
  - **Automatic fallback** — `VideoFormat.h265` is used only when the device can encode HEVC in hardware (Android: a non-software `video/hevc` encoder; iOS/macOS: an advertised HEVC encoder). On devices without it, the compressor transparently falls back to H.264 instead of failing.
  - **`OnSuccess.usedFormat`** — every successful result now reports the codec actually used, so you can tell whether an H.265 request was honoured or fell back to H.264.
- Example app gains a **“Use H.265 (HEVC)”** toggle in both the single and batch flows, and the single-video result now shows the codec used.
