### PR TITLE
Feature/ios audio crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 1.8.3
+# 1.9.0
+
+### New
+
+- **Tap the foreground notification to reopen the app (Android, [#16](https://github.com/Farid023/light_compressor_v2/issues/16)):** the ongoing compression notification now carries a content intent, so tapping it brings the running app forward (`FLAG_ACTIVITY_REORDER_TO_FRONT`). With a task-reusing host activity (Flutter's default `launchMode="singleTop"`) the existing Flutter state is kept; after a full process kill it cold-starts. Thanks [@khlebobul](https://github.com/khlebobul) ([#18](https://github.com/Farid023/light_compressor_v2/pull/18)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.8.3
+
+### Fixed
+
+- **Batch progress bounds:** `BatchProgress.percent` and `overallPercent` are now clamped to `0..100`, matching single-video progress — a native value that rounds just over `100` (or a transient negative) no longer leaks into batch progress UIs.
+
 # 1.8.2
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **iOS/macOS crash when compressing videos that have audio ([#17](https://github.com/Farid023/light_compressor_v2/issues/17)):** with no `AudioConfig` (the default), the source audio is muxed through unchanged. The native audio writer input was created without the source format description, which made `AVAssetWriter` throw `NSInvalidArgumentException` ("provide a format hint") on a **physical iOS device** — reproducing 100% on `.mov` camera recordings (they always carry an audio track). The input now carries the source `CMFormatDescription`, so passthrough muxing to the `.mp4` container succeeds. The simulator and macOS did not surface the crash, which is why it slipped past.
 - **Batch progress bounds:** `BatchProgress.percent` and `overallPercent` are now clamped to `0..100`, matching single-video progress — a native value that rounds just over `100` (or a transient negative) no longer leaks into batch progress UIs.
 
 # 1.8.2

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the dependency:
 
 ```yaml
 dependencies:
-  light_compressor_v2: ^1.8.2
+  light_compressor_v2: ^1.8.3
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the dependency:
 
 ```yaml
 dependencies:
-  light_compressor_v2: ^1.8.3
+  light_compressor_v2: ^1.9.0
 ```
 
 ```bash

--- a/example/integration_test/edge_invariants_test.dart
+++ b/example/integration_test/edge_invariants_test.dart
@@ -207,4 +207,35 @@ void main() {
       timeout: const Timeout(Duration(seconds: 120)),
     );
   });
+
+  group('audio passthrough mux (issue #17)', () {
+    testWidgets(
+      'default compression of an audio-bearing clip does not crash the writer',
+      (WidgetTester tester) async {
+        if (source == null) return markTestSkipped(kNoClipSkipReason);
+
+        // Regression guard for issue #17. With NO AudioConfig (the default), the
+        // source audio is muxed through untouched. The native writer needs the
+        // source format description to do that; without it, AVAssetWriter's
+        // addInput throws NSInvalidArgumentException ("provide a format hint")
+        // on a REAL iOS device. The simulator and macOS are lenient, so this
+        // stays green there whether or not the fix is present — its value is on
+        // physical iOS hardware / CI-on-device.
+        final Result result = await compressor.compressVideo(
+          path: source!,
+          videoQuality: VideoQuality.medium,
+          isMinBitrateCheckEnabled: false,
+          video: Video(videoName: 'lc_edge_audiopass'),
+          android: AndroidConfig(isSharedStorage: false),
+          ios: IOSConfig(saveInGallery: false),
+        );
+
+        expect(result, isA<OnSuccess>(),
+            reason: 'passthrough audio compression must not crash or fail');
+        await expectReadableVideo(
+            compressor, (result as OnSuccess).destinationPath);
+      },
+      timeout: const Timeout(Duration(seconds: 120)),
+    );
+  });
 }

--- a/example/integration_test/edge_invariants_test.dart
+++ b/example/integration_test/edge_invariants_test.dart
@@ -1,0 +1,210 @@
+// Edge-invariant tests on the REAL native pipeline — written to *catch bugs*,
+// not to pad coverage. Each targets a cross-cutting guarantee that the existing
+// suite does not stress directly, and that is plausible to break in the native
+// engines (Android MediaCodec/MediaMuxer, Apple AVFoundation):
+//
+//   * a batch where EVERY item fails still returns one result per slot, in
+//     order, and completes (no deadlock / dropped slot);
+//   * cancelling a batch never makes a slot reply twice or go missing —
+//     exactly one terminal completion per input index;
+//   * a trim reports the TRIMMED duration on OnSuccess.duration (the size
+//     solver and progress denominator rely on it — the output file being short
+//     is not enough);
+//   * every progress sample from the real native side stays within 0..100.
+//
+// Requires a real input clip at example/integration_test/assets/sample.mp4 (the
+// committed file is a tiny placeholder — these tests SKIP until it is replaced).
+//
+//   cd example && flutter test integration_test/edge_invariants_test.dart -d <deviceId>
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:light_compressor_v2/light_compressor_v2.dart';
+
+import 'support.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final LightCompressor compressor = LightCompressor();
+  String? source;
+
+  setUpAll(() async {
+    source = await prepareSampleSource();
+  });
+
+  group('batch invariants (real device)', () {
+    const String bogusA = '/does/not/exist_lc_edge_a.mp4';
+    const String bogusB = '/does/not/exist_lc_edge_b.mp4';
+    const String bogusC = '/does/not/exist_lc_edge_c.mp4';
+
+    testWidgets(
+      'a batch where every item fails still returns one OnFailure per slot',
+      (WidgetTester tester) async {
+        if (source == null) return markTestSkipped(kNoClipSkipReason);
+
+        final List<Result> results = await compressor.compressVideos(
+          paths: <String>[bogusA, bogusB, bogusC],
+          videoNames: <String>['lc_edge_f0', 'lc_edge_f1', 'lc_edge_f2'],
+          videoQuality: VideoQuality.medium,
+          isMinBitrateCheckEnabled: false,
+          android: AndroidConfig(isSharedStorage: false),
+          ios: IOSConfig(saveInGallery: false),
+        );
+
+        // The whole point: an all-bad batch must still complete (not hang) and
+        // fill every slot with a terminal failure, in input order.
+        expect(results, hasLength(3));
+        for (final Result r in results) {
+          expect(r, isA<OnFailure>(),
+              reason: 'every bogus path must fail its own slot');
+          expect((r as OnFailure).message, isNotEmpty);
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 120)),
+    );
+
+    testWidgets(
+      'cancelling a batch yields exactly one terminal reply per index',
+      (WidgetTester tester) async {
+        if (source == null) return markTestSkipped(kNoClipSkipReason);
+
+        final List<BatchItemCompleted> completions = <BatchItemCompleted>[];
+        final sub = compressor.onBatchUpdate.listen((BatchEvent e) {
+          if (e is BatchItemCompleted) completions.add(e);
+        });
+
+        final Future<List<Result>> pending = compressor.compressVideos(
+          paths: <String>[source!, source!, source!],
+          videoNames: <String>['lc_edge_c0', 'lc_edge_c1', 'lc_edge_c2'],
+          videoQuality: VideoQuality.medium,
+          isMinBitrateCheckEnabled: false,
+          android: AndroidConfig(isSharedStorage: false),
+          ios: IOSConfig(saveInGallery: false),
+        );
+
+        // Tolerant by design: on a short clip the batch may finish before the
+        // cancel lands. The invariant under test holds either way — no slot may
+        // reply twice ("replying twice crashes the engine") and none may vanish.
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        await compressor.cancelCompression();
+        final List<Result> results = await pending;
+        await sub.cancel();
+
+        // Every input index resolved to exactly one terminal result, in order.
+        expect(results, hasLength(3));
+        for (final Result r in results) {
+          expect(
+            r is OnSuccess || r is OnFailure || r is OnCancelled,
+            isTrue,
+            reason: 'each slot must reach a terminal result',
+          );
+        }
+
+        // The completion stream must show each index at most once (a duplicate
+        // index would mean a slot fired twice — the reply-once violation).
+        final List<int> indices =
+            completions.map((BatchItemCompleted e) => e.index).toList();
+        expect(
+          indices.toSet().length,
+          indices.length,
+          reason: 'an index appearing twice means a slot replied twice: '
+              '$indices',
+        );
+        for (final int i in indices) {
+          expect(i, inInclusiveRange(0, 2),
+              reason: 'completion index $i is outside the input range');
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 180)),
+    );
+  });
+
+  group('trim reports the trimmed duration (real device)', () {
+    testWidgets(
+      'OnSuccess.duration reflects the kept range, not the source length',
+      (WidgetTester tester) async {
+        if (source == null) return markTestSkipped(kNoClipSkipReason);
+
+        final Duration? srcDuration =
+            (await compressor.getMediaInfo(source!)).duration;
+        expect(srcDuration, isNotNull);
+        final int srcMs = srcDuration!.inMilliseconds;
+        if (srcMs < 1000) {
+          return markTestSkipped(
+              'sample clip is too short to trim meaningfully');
+        }
+
+        final int startMs = (srcMs * 0.25).round();
+        final int endMs = (srcMs * 0.75).round();
+        final double expectedSec = (endMs - startMs) / 1000.0;
+
+        final Result result = await compressor.compressVideo(
+          path: source!,
+          videoQuality: VideoQuality.medium,
+          isMinBitrateCheckEnabled: false,
+          video: Video(videoName: 'lc_edge_trimdur'),
+          android: AndroidConfig(isSharedStorage: false),
+          ios: IOSConfig(saveInGallery: false),
+          edit: VideoEdit(trimStartMs: startMs, trimEndMs: endMs),
+        );
+
+        expect(result, isA<OnSuccess>());
+        final OnSuccess ok = result as OnSuccess;
+
+        // The reported duration must be the TRIMMED span, well under the source.
+        // If the native reports the source length here, the size solver and the
+        // progress denominator are both wrong even though the output file is
+        // short — this is what the assertion guards.
+        expect(
+          ok.duration,
+          lessThan(srcMs / 1000.0 - 0.1),
+          reason:
+              'reported duration ${ok.duration}s should be the trimmed span, '
+              'not the ${srcMs / 1000.0}s source',
+        );
+        expect(
+          ok.duration,
+          greaterThan(expectedSec * 0.5),
+          reason: 'reported duration ${ok.duration}s is far below the '
+              'requested ~${expectedSec}s',
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 120)),
+    );
+  });
+
+  group('progress stays in range (real device)', () {
+    testWidgets(
+      'every onProgressDetail sample is within 0..100',
+      (WidgetTester tester) async {
+        if (source == null) return markTestSkipped(kNoClipSkipReason);
+
+        final List<double> percents = <double>[];
+        final sub = compressor.onProgressDetail.listen((CompressionProgress p) {
+          percents.add(p.percent);
+        });
+
+        final Result result = await compressor.compressVideo(
+          path: source!,
+          videoQuality: VideoQuality.medium,
+          isMinBitrateCheckEnabled: false,
+          video: Video(videoName: 'lc_edge_prog'),
+          android: AndroidConfig(isSharedStorage: false),
+          ios: IOSConfig(saveInGallery: false),
+        );
+        await sub.cancel();
+
+        expect(result, isA<OnSuccess>());
+        expect(percents, isNotEmpty,
+            reason: 'a real compression should emit progress');
+        for (final double p in percents) {
+          expect(p.isNaN, isFalse, reason: 'progress emitted NaN');
+          expect(p, inInclusiveRange(0.0, 100.0),
+              reason: 'native emitted an out-of-range percent: $p');
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 120)),
+    );
+  });
+}

--- a/ios/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
+++ b/ios/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
@@ -877,7 +877,21 @@ public struct LightCompressor {
                 // The reader must decompress to PCM so the writer can re-encode.
                 readerSettings = [AVFormatIDKey: Int(kAudioFormatLinearPCM)]
             }
-            let input = AVAssetWriterInput(mediaType: .audio, outputSettings: writerSettings)
+            let input: AVAssetWriterInput
+            if let writerSettings {
+                input = AVAssetWriterInput(
+                    mediaType: .audio, outputSettings: writerSettings)
+            } else {
+                // Passthrough mux: AVAssetWriter needs the source format
+                // description to write the original audio samples into the .mp4
+                // container. Without it, add(_:) throws NSInvalidArgumentException
+                // ("provide a format hint") on a real device (issue #17); the
+                // simulator is lenient, which is why it slipped past sim runs.
+                let hint = (audioTrack.formatDescriptions as? [CMFormatDescription])?
+                    .first
+                input = AVAssetWriterInput(
+                    mediaType: .audio, outputSettings: nil, sourceFormatHint: hint)
+            }
             input.expectsMediaDataInRealTime = false
             videoWriter.add(input)
             audioWriterInput = input

--- a/lib/src/light_compressor.dart
+++ b/lib/src/light_compressor.dart
@@ -99,8 +99,12 @@ class LightCompressor {
         final int? eta = (map['etaMs'] as num?)?.toInt();
         return BatchProgress(
           index: index,
-          percent: (map['percent'] as num?)?.toDouble() ?? 0.0,
-          overallPercent: (map['overallPercent'] as num?)?.toDouble() ?? 0.0,
+          percent: ((map['percent'] as num?)?.toDouble() ?? 0.0)
+              .clamp(0.0, 100.0)
+              .toDouble(),
+          overallPercent: ((map['overallPercent'] as num?)?.toDouble() ?? 0.0)
+              .clamp(0.0, 100.0)
+              .toDouble(),
           bytesProcessed: (map['bytesProcessed'] as num?)?.toInt(),
           etaMs: (eta == null || eta < 0) ? null : eta,
           elapsedMs: (map['elapsedMs'] as num?)?.toInt(),

--- a/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
+++ b/macos/light_compressor_v2/Sources/light_compressor_v2/LightCompressor.swift
@@ -877,7 +877,21 @@ public struct LightCompressor {
                 // The reader must decompress to PCM so the writer can re-encode.
                 readerSettings = [AVFormatIDKey: Int(kAudioFormatLinearPCM)]
             }
-            let input = AVAssetWriterInput(mediaType: .audio, outputSettings: writerSettings)
+            let input: AVAssetWriterInput
+            if let writerSettings {
+                input = AVAssetWriterInput(
+                    mediaType: .audio, outputSettings: writerSettings)
+            } else {
+                // Passthrough mux: AVAssetWriter needs the source format
+                // description to write the original audio samples into the .mp4
+                // container. Without it, add(_:) throws NSInvalidArgumentException
+                // ("provide a format hint") on a real device (issue #17); the
+                // simulator is lenient, which is why it slipped past sim runs.
+                let hint = (audioTrack.formatDescriptions as? [CMFormatDescription])?
+                    .first
+                input = AVAssetWriterInput(
+                    mediaType: .audio, outputSettings: nil, sourceFormatHint: hint)
+            }
             input.expectsMediaDataInRealTime = false
             videoWriter.add(input)
             audioWriterInput = input

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: light_compressor_v2
 description: Native light video compression for Flutter (No FFmpeg) — single or batch, H.264/H.265, target size, trim, rotate and colour, with live progress and cancellation.
-version: 1.8.2
+version: 1.8.3
 repository: https://github.com/Farid023/light_compressor_v2
 issue_tracker: https://github.com/Farid023/light_compressor_v2/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: light_compressor_v2
 description: Native light video compression for Flutter (No FFmpeg) — single or batch, H.264/H.265, target size, trim, rotate and colour, with live progress and cancellation.
-version: 1.8.3
+version: 1.9.0
 repository: https://github.com/Farid023/light_compressor_v2
 issue_tracker: https://github.com/Farid023/light_compressor_v2/issues
 

--- a/test/edge_cases_test.dart
+++ b/test/edge_cases_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:light_compressor_v2/light_compressor_v2.dart';
+
+/// Adversarial edge-case tests aimed at *finding* defects, not padding coverage.
+///
+/// Some tests here assert the behaviour the contract *should* have (e.g. progress
+/// must be within 0..100 on every path). If one fails, it has surfaced a real
+/// inconsistency in the library — that is the point.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final LightCompressor compressor = LightCompressor();
+  const MethodChannel method = MethodChannel('light_compressor');
+  const EventChannel single = EventChannel('compression/stream');
+  const EventChannel batch = EventChannel('compression/batch-stream');
+  final List<MethodCall> log = <MethodCall>[];
+  String compressResponse = '';
+  Object? batchResponse;
+
+  final TestDefaultBinaryMessenger messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  setUp(() {
+    messenger.setMockMethodCallHandler(method, (MethodCall call) async {
+      log.add(call);
+      if (call.method == 'startBatchCompression') return batchResponse;
+      return compressResponse;
+    });
+  });
+
+  tearDown(() {
+    log.clear();
+    batchResponse = null;
+    messenger
+      ..setMockMethodCallHandler(method, null)
+      ..setMockStreamHandler(single, null)
+      ..setMockStreamHandler(batch, null);
+  });
+
+  void emitBatch(List<Map<String, dynamic>> events) {
+    messenger.setMockStreamHandler(
+      batch,
+      MockStreamHandler.inline(
+        onListen: (Object? args, MockStreamHandlerEventSink sink) {
+          for (final Map<String, dynamic> e in events) {
+            sink.success(e);
+          }
+          sink.endOfStream();
+        },
+      ),
+    );
+  }
+
+  void emitSingle(List<Object?> events) {
+    messenger.setMockStreamHandler(
+      single,
+      MockStreamHandler.inline(
+        onListen: (Object? args, MockStreamHandlerEventSink sink) {
+          for (final Object? e in events) {
+            sink.success(e);
+          }
+          sink.endOfStream();
+        },
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Progress must always be a sane 0..100 on EVERY path. The single-video path
+  // clamps (compression_progress.dart); these check the batch path matches.
+  // ---------------------------------------------------------------------------
+
+  group('progress bounds', () {
+    test('batch per-item percent is clamped to 0..100 (like the single path)',
+        () async {
+      emitBatch(<Map<String, dynamic>>[
+        <String, dynamic>{'type': 'progress', 'index': 0, 'percent': 150.0},
+        <String, dynamic>{'type': 'progress', 'index': 0, 'percent': -10.0},
+      ]);
+
+      final List<BatchEvent> events =
+          await compressor.onBatchUpdate.take(2).toList();
+
+      expect((events[0] as BatchProgress).percent, 100.0);
+      expect((events[1] as BatchProgress).percent, 0.0);
+    });
+
+    test('batch overallPercent is clamped to 0..100', () async {
+      emitBatch(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'type': 'progress',
+          'index': 0,
+          'percent': 50.0,
+          'overallPercent': 150.0,
+        },
+      ]);
+
+      final BatchProgress p = (await compressor.onBatchUpdate.take(1).toList())
+          .first as BatchProgress;
+
+      expect(p.overallPercent, 100.0);
+    });
+
+    test('CONTRAST: single onProgressDetail percent IS clamped', () async {
+      emitSingle(<Object?>[
+        <String, dynamic>{'percent': 150.0}
+      ]);
+
+      final CompressionProgress p =
+          (await compressor.onProgressDetail.take(1).toList()).first;
+
+      expect(p.percent, 100.0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Numeric-safety guards: never emit NaN / Infinity / crash on odd sizes.
+  // ---------------------------------------------------------------------------
+
+  group('ratio safety', () {
+    test('ratio is 0.0 (never NaN) when originalSize is 0', () async {
+      compressResponse = jsonEncode(<String, dynamic>{
+        'onSuccess': '/nonexistent-output.mp4',
+        'duration': 1.0,
+        'originalSize': 0,
+        'compressedSize': 0,
+      });
+
+      final Result r = await compressor.compressVideo(
+        path: '/nonexistent-input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'out.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      expect(r, isA<OnSuccess>());
+      final double ratio = (r as OnSuccess).ratio;
+      expect(ratio.isNaN, isFalse);
+      expect(ratio.isInfinite, isFalse);
+      expect(ratio, 0.0);
+    });
+
+    test('ratio stays within 0..100 for a huge compressed size', () async {
+      compressResponse = jsonEncode(<String, dynamic>{
+        'onSuccess': '/nonexistent-output.mp4',
+        'duration': 1.0,
+        'originalSize': 10,
+        'compressedSize': 9999999999,
+      });
+
+      final OnSuccess r = await compressor.compressVideo(
+        path: '/nonexistent-input.mp4',
+        videoQuality: VideoQuality.medium,
+        video: Video(videoName: 'out.mp4'),
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      ) as OnSuccess;
+
+      expect(r.ratio, inInclusiveRange(0.0, 100.0));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // compressVideos input-contract guards.
+  // ---------------------------------------------------------------------------
+
+  group('compressVideos contract', () {
+    test('empty paths short-circuits to [] without hitting the channel',
+        () async {
+      final List<Result> results = await compressor.compressVideos(
+        paths: <String>[],
+        videoNames: <String>[],
+        videoQuality: VideoQuality.medium,
+        android: AndroidConfig(),
+        ios: IOSConfig(),
+      );
+
+      expect(results, isEmpty);
+      expect(
+        log.where((MethodCall c) => c.method == 'startBatchCompression'),
+        isEmpty,
+      );
+    });
+
+    test('mismatched paths/videoNames lengths throw before the channel', () {
+      expect(
+        () => compressor.compressVideos(
+          paths: <String>['/a.mp4', '/b.mp4'],
+          videoNames: <String>['only-one.mp4'],
+          videoQuality: VideoQuality.medium,
+          android: AndroidConfig(),
+          ios: IOSConfig(),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# 1.9.0

### New

- **Tap the foreground notification to reopen the app (Android, [#16](https://github.com/Farid023/light_compressor_v2/issues/16)):** the ongoing compression notification now carries a content intent, so tapping it brings the running app forward (`FLAG_ACTIVITY_REORDER_TO_FRONT`). With a task-reusing host activity (Flutter's default `launchMode="singleTop"`) the existing Flutter state is kept; after a full process kill it cold-starts. Thanks [@khlebobul](https://github.com/khlebobul) ([#18](https://github.com/Farid023/light_compressor_v2/pull/18)).

### Fixed

- **iOS/macOS crash when compressing videos that have audio ([#17](https://github.com/Farid023/light_compressor_v2/issues/17)):** with no `AudioConfig` (the default), the source audio is muxed through unchanged. The native audio writer input was created without the source format description, which made `AVAssetWriter` throw `NSInvalidArgumentException` ("provide a format hint") on a **physical iOS device** — reproducing 100% on `.mov` camera recordings (they always carry an audio track). The input now carries the source `CMFormatDescription`, so passthrough muxing to the `.mp4` container succeeds. The simulator and macOS did not surface the crash, which is why it slipped past.
- **Batch progress bounds:** `BatchProgress.percent` and `overallPercent` are now clamped to `0..100`, matching single-video progress — a native value that rounds just over `100` (or a transient negative) no longer leaks into batch progress UIs.